### PR TITLE
Add Lopster rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/chemlog/cli.py
+++ b/chemlog/cli.py
@@ -56,9 +56,9 @@ def resolve_chebi_classes(classification):
     if charge_category == ChargeCategories.SALT.name:
         res.append("24866")  # salt (there is no class peptide salt)
     elif charge_category == ChargeCategories.ANION.name:
-        res.append("25696")
+        res.append("22563")
     elif charge_category == ChargeCategories.CATION.name:
-        res.append("25697")
+        res.append("36961")
     elif charge_category == ChargeCategories.ZWITTERION.name:
         res.append("27369")
     if n_amino_acid_residues >= 2:

--- a/chemlog/fol_to_py/folToPyTranslator.py
+++ b/chemlog/fol_to_py/folToPyTranslator.py
@@ -23,7 +23,8 @@ for i in range(1, 119):
 for i in range(5):
     PREDICATE_NAME_RDKIT_MAPPING[f"has{i}hs"] = lambda a, i=i: f"{a}.GetTotalNumHs() == {i}"
 for charge in range(-3, 4):
-    PREDICATE_NAME_RDKIT_MAPPING[f"charge{charge}"] = lambda a, charge=charge: f"{a}.GetFormalCharge() == {charge}"
+    charge_key = f"charge_m{-charge}" if charge < 0 else f"charge{charge}"
+    PREDICATE_NAME_RDKIT_MAPPING[charge_key] = lambda a, charge=charge: f"{a}.GetFormalCharge() == {charge}"
 
 class PythonCompiler(Compiler):
     """
@@ -47,6 +48,8 @@ class PythonCompiler(Compiler):
             return "and"
         elif connective == fol.BinaryConnective.DISJUNCTION:
             return "or"
+        elif connective == fol.BinaryConnective.NEQ:
+            return "!="
         else:
             raise NotImplementedError(f"Binary connective {connective} not supported in Python Compiler.")
 

--- a/chemlog/lopster/lopster_classifier.py
+++ b/chemlog/lopster/lopster_classifier.py
@@ -39,7 +39,7 @@ lopster_chebi_mapping = {
     "carboxylicEster": "33308",
     "amine": "32952",
     "aldehyde": "17478",
-    #"cyclic": "33595",
+    "cyclic": "33595",
     "ketone": "17087",
     "organophosphorus": "25710",
     "alkane": "18310",
@@ -48,6 +48,11 @@ lopster_chebi_mapping = {
 }
 
 class LopsterClassifier(Classifier):
+
+    def __init__(self, cyclic_mode=False):
+        # the original paper evaluates the cyclicity related rules separately
+        # here, using cyclic_mode=True might result in performance issues
+        self.cyclic_mode = cyclic_mode
 
     def classify(self, mol_list):
         res = []
@@ -58,7 +63,7 @@ class LopsterClassifier(Classifier):
                 res.append({})
                 continue
             res.append({cls: self.get_single_classification(mol, lopster_predicate)
-                        for lopster_predicate, cls in lopster_chebi_mapping.items()})
+                        for lopster_predicate, cls in lopster_chebi_mapping.items() if self.cyclic_mode or cls != "33595"})
         return res
     
     def get_single_classification(self, mol, lopster_predicate):

--- a/chemlog/lopster/lopster_classifier.py
+++ b/chemlog/lopster/lopster_classifier.py
@@ -29,7 +29,7 @@ lopster_chebi_mapping = {
     "chromiumGroupMolEntity": "33741",
     "nobleGasMolEntity": "33583",
     "carbonMolEntity": "50860",
-    "oxygenMolEntity": "25805",
+    "oxygenMolEntity": "25806",
     "hydrogenMolEntity": "33608",
     "phosphorusMolEntity": "26082",
     "inorganic": "24835",
@@ -46,7 +46,10 @@ lopster_chebi_mapping = {
     "organophosphorus": "25710",
     "alkane": "18310",
     "haloAlkane": "24469",
-    "heteroOrganic": "33285"
+    "heteroOrganic": "33285",
+    # new
+    "livermoriumMolEntity": "194538",
+    "moscoviumMolEntity": "194536",
 }
 
 class LopsterClassifier(Classifier):
@@ -66,7 +69,8 @@ class LopsterClassifier(Classifier):
                 continue
             ress = {}
             for lopster_predicate, cls in lopster_chebi_mapping.items():
-                if not self.cyclic_mode and cls == "33595":
+                # some classes are only defined in cyclic mode
+                if not self.cyclic_mode and cls in ["33595", "18310", "24469"]:
                     continue
                 #print(f"Classifying {cls} using {lopster_predicate}")
                 ress[cls] = self.get_single_classification(mol, lopster_predicate)
@@ -82,9 +86,8 @@ class LopsterClassifier(Classifier):
 
 class LopsterClingoClassifier(LopsterClassifier):
 
-    def __init__(self, cyclic_mode=False, batch_size=10):
+    def __init__(self, cyclic_mode=False):
         super().__init__(cyclic_mode)
-        self.batch_size = batch_size
         self.rules_file_atom = os.path.join(os.path.dirname(__file__), 'lopster_rules_atom_level.pl')
         self.rules_file_molecule = os.path.join(os.path.dirname(__file__), 'lopster_rules_molecule_level.pl')
         
@@ -113,12 +116,15 @@ class LopsterClingoClassifier(LopsterClassifier):
 
     def classify(self, mol_list_all, verbose=False):
         res = []
-        idx = 0
-        for mol_list in mol_list_all[idx:idx + self.batch_size]:
-            idx += self.batch_size
-            if not isinstance(mol_list, list):
-                mol_list = [mol_list]
-            lp = self.build_logic_program(mol_list)
+        for idx in tqdm(range(0, len(mol_list_all)), desc="Lopster Clingo classification"):
+            mol = mol_list_all[idx]
+            try:
+                from rdkit import Chem
+                mol = Chem.AddHs(mol)
+            except Exception as e:
+                print(f"Failed to add Hs to molecule: {e}")
+                pass
+            lp = self.build_logic_program([mol])
             if verbose:
                 print("Generated logic program for Clingo -> demo_lopster_clingo.lp")
                 with open("demo_lopster_clingo.lp", 'w+', encoding='utf-8') as f:
@@ -137,27 +143,25 @@ class LopsterClingoClassifier(LopsterClassifier):
             if verbose:
                 print("Clingo solution:", solution)
                 print("Model list:", model_list)
-            for mol_index in range(len(mol_list)):
-                ress = {}
-                for lopster_predicate, cls in lopster_chebi_mapping.items():
-                    if not self.cyclic_mode and cls == "33595":
-                        continue
-                    predicate_found = False
-                    for symbol in model_list:
-                        if str(symbol) == f"{lopster_predicate}(c_mol_{mol_index})":
-                            predicate_found = True
-                            break
-                    ress[cls] = predicate_found
-                res.append(ress)
+            mol_index = 0 # change this if multiple molecules are processed at once
+            ress = {}
+            for lopster_predicate, cls in lopster_chebi_mapping.items():
+                if not self.cyclic_mode and cls in ["33595", "18310", "24469"]:
+                    continue
+                predicate_found = False
+                for symbol in model_list:
+                    if str(symbol) == f"{lopster_predicate}(c_mol_{mol_index})":
+                        predicate_found = True
+                        break
+                ress[cls] = predicate_found
+            res.append(ress)
             
-            if idx >= len(mol_list_all):
-                break
         return res
         
 
 if __name__ == "__main__":
     from rdkit import Chem
     mol = Chem.MolFromSmiles("NC(CC(=O)O)C(=O)O") # aspartic acid
-    #mol = Chem.MolFromSmiles(r"[Cl-].[H][N+](C)(C)CC\C=C1\c2ccccc2CSc2ccccc12")
+    mol = Chem.MolFromSmiles(r"OC(CC[NH+]1CCCCC1)(c1ccccc1)C1CC2C=CC1C2.[Cl-]")
     #print(LopsterClassifier().classify(mol))
-    print(LopsterClingoClassifier().classify([mol], verbose=False))
+    print(LopsterClingoClassifier().classify([mol], verbose=True))

--- a/chemlog/lopster/lopster_classifier.py
+++ b/chemlog/lopster/lopster_classifier.py
@@ -1,5 +1,7 @@
 
 
+import os
+from tqdm import tqdm
 from chemlog.base_classifier import Classifier
 
 
@@ -58,12 +60,17 @@ class LopsterClassifier(Classifier):
         res = []
         if not isinstance(mol_list, list):
             mol_list = [mol_list]
-        for mol in mol_list:
+        for mol in tqdm(mol_list, desc="Lopster classification"):
             if not mol:
                 res.append({})
                 continue
-            res.append({cls: self.get_single_classification(mol, lopster_predicate)
-                        for lopster_predicate, cls in lopster_chebi_mapping.items() if self.cyclic_mode or cls != "33595"})
+            ress = {}
+            for lopster_predicate, cls in lopster_chebi_mapping.items():
+                if not self.cyclic_mode and cls == "33595":
+                    continue
+                #print(f"Classifying {cls} using {lopster_predicate}")
+                ress[cls] = self.get_single_classification(mol, lopster_predicate)
+            res.append(ress)
         return res
     
     def get_single_classification(self, mol, lopster_predicate):
@@ -72,7 +79,85 @@ class LopsterClassifier(Classifier):
         func = getattr(lopster, lopster_predicate)
         return func(mol, None)
 
+
+class LopsterClingoClassifier(LopsterClassifier):
+
+    def __init__(self, cyclic_mode=False, batch_size=10):
+        super().__init__(cyclic_mode)
+        self.batch_size = batch_size
+        self.rules_file_atom = os.path.join(os.path.dirname(__file__), 'lopster_rules_atom_level.pl')
+        self.rules_file_molecule = os.path.join(os.path.dirname(__file__), 'lopster_rules_molecule_level.pl')
+        
+        self.lopster_rules = ""
+        with open(self.rules_file_atom, 'r', encoding='utf-8') as f:
+            for line in f:
+                if cyclic_mode or (not "cyclic" in line and not "cleanReachable" in line):
+                    self.lopster_rules += line
+        
+        with open(self.rules_file_molecule, 'r', encoding='utf-8') as f:
+            for line in f:
+                # filter out cyclicity related rules if not in cyclic mode
+                if cyclic_mode or (not "cyclic" in line and not "cleanReachable" in line):
+                    self.lopster_rules += line
+
+    def build_logic_program(self, mol_list):
+        from chemlog.lopster.lopster_code.dg_generator import DGGenerator
+        from chemlog.lopster.lopster_code.dlv_program_manager import DLVProgramManager
+        dg_generator = DGGenerator()
+        description_graphs = dg_generator.assemble_dg_map(mol_list)
+
+        dlv_manager = DLVProgramManager(description_graphs)
+        program = dlv_manager.create_dlv_programs(mol_list)
+
+        return program + "\n" + self.lopster_rules
+
+    def classify(self, mol_list_all, verbose=False):
+        res = []
+        idx = 0
+        for mol_list in mol_list_all[idx:idx + self.batch_size]:
+            idx += self.batch_size
+            if not isinstance(mol_list, list):
+                mol_list = [mol_list]
+            lp = self.build_logic_program(mol_list)
+            if verbose:
+                print("Generated logic program for Clingo -> demo_lopster_clingo.lp")
+                with open("demo_lopster_clingo.lp", 'w+', encoding='utf-8') as f:
+                    f.write(lp)
+            import clingo
+            if not verbose:
+                ctl = clingo.Control(message_limit=0) # silent mode
+            else:
+                ctl = clingo.Control()
+            ctl.add("base", [], lp)
+            ctl.ground([("base", [])])
+            model_list = []
+            solution = ctl.solve(yield_=True)
+            for m in solution:
+                model_list = m.symbols(shown=True)
+            if verbose:
+                print("Clingo solution:", solution)
+                print("Model list:", model_list)
+            for mol_index in range(len(mol_list)):
+                ress = {}
+                for lopster_predicate, cls in lopster_chebi_mapping.items():
+                    if not self.cyclic_mode and cls == "33595":
+                        continue
+                    predicate_found = False
+                    for symbol in model_list:
+                        if str(symbol) == f"{lopster_predicate}(c_mol_{mol_index})":
+                            predicate_found = True
+                            break
+                    ress[cls] = predicate_found
+                res.append(ress)
+            
+            if idx >= len(mol_list_all):
+                break
+        return res
+        
+
 if __name__ == "__main__":
     from rdkit import Chem
     mol = Chem.MolFromSmiles("NC(CC(=O)O)C(=O)O") # aspartic acid
-    print(LopsterClassifier().classify(mol))
+    #mol = Chem.MolFromSmiles(r"[Cl-].[H][N+](C)(C)CC\C=C1\c2ccccc2CSc2ccccc12")
+    #print(LopsterClassifier().classify(mol))
+    print(LopsterClingoClassifier().classify([mol], verbose=False))

--- a/chemlog/lopster/lopster_classifier.py
+++ b/chemlog/lopster/lopster_classifier.py
@@ -1,0 +1,73 @@
+
+
+from chemlog.base_classifier import Classifier
+
+
+lopster_chebi_mapping = {
+    "astatineMolEntity": "37138",
+    "bromineMolEntity": "22928", 
+    "chlorineMolEntity": "23117", 
+    "fluorineMolEntity": "24062",
+    "iodineMolEntity": "24860", 
+    "halogenMolEntity": "24471", 
+    "poloniumMolEntity": "36917", 
+    "seleniumMolEntity": "26628",
+    "sulfurMolEntity": "26835",
+    "telluriumMolEntity": "33305",
+    "chalcogenMolEntity": "33304",
+    "antimonyMolEntity": "36919",
+    "arsenicMolEntity": "22632",
+    "bismuthMolEntity": "37196",
+    "nitrogenMolEntity": "51143",
+    "pnictogenMolEntity": "33302",
+    "chromiumMolEntity": "23237",
+    "molybdenumMolEntity": "25370",
+    "seaborgiumMolEntity": "37224",
+    "tungstenMolEntity": "33742",
+    "chromiumGroupMolEntity": "33741",
+    "nobleGasMolEntity": "33583",
+    "carbonMolEntity": "50860",
+    "oxygenMolEntity": "25805",
+    "hydrogenMolEntity": "33608",
+    "phosphorusMolEntity": "26082",
+    "inorganic": "24835",
+    "hydroCarbon": "24632",
+    "haloHydroCarbon": "24472",
+    "polyatomic": "36357",
+    "monoatomic": "33238",
+    "carboxylicAcid": "33575",
+    "carboxylicEster": "33308",
+    "amine": "32952",
+    "aldehyde": "17478",
+    #"cyclic": "33595",
+    "ketone": "17087",
+    "organophosphorus": "25710",
+    "alkane": "18310",
+    "haloAlkane": "24469",
+    "heteroOrganic": "33285"
+}
+
+class LopsterClassifier(Classifier):
+
+    def classify(self, mol_list):
+        res = []
+        if not isinstance(mol_list, list):
+            mol_list = [mol_list]
+        for mol in mol_list:
+            if not mol:
+                res.append({})
+                continue
+            res.append({cls: self.get_single_classification(mol, lopster_predicate)
+                        for lopster_predicate, cls in lopster_chebi_mapping.items()})
+        return res
+    
+    def get_single_classification(self, mol, lopster_predicate):
+        import chemlog.lopster.lopster_python as lopster
+        # call function with lopster predicate name
+        func = getattr(lopster, lopster_predicate)
+        return func(mol, None)
+
+if __name__ == "__main__":
+    from rdkit import Chem
+    mol = Chem.MolFromSmiles("NC(CC(=O)O)C(=O)O") # aspartic acid
+    print(LopsterClassifier().classify(mol))

--- a/chemlog/lopster/lopster_code/atom.py
+++ b/chemlog/lopster/lopster_code/atom.py
@@ -1,0 +1,18 @@
+from typing import List
+
+class Atom:
+    """Data structure for first-order logic atoms."""
+    def __init__(self, predicate: str, terms: List[str]):
+        self.predicate = predicate
+        self.terms = list(terms)
+
+    def get_predicate(self) -> str:
+        return self.predicate
+
+    def get_terms(self) -> List[str]:
+        return self.terms
+
+    def text_representation(self) -> str:
+        if not self.terms:
+            return self.predicate
+        return f"{self.predicate}({','.join(self.terms)})"

--- a/chemlog/lopster/lopster_code/description_graph.py
+++ b/chemlog/lopster/lopster_code/description_graph.py
@@ -1,0 +1,35 @@
+from typing import Set
+from .node import Node
+from .edge import Edge
+
+class DescriptionGraph:
+    """Data structure for description graphs: set of nodes, edges and start concept."""
+    def __init__(self, nodes: Set[Node], edges: Set[Edge], start_concept: str):
+        self.nodes = set(nodes)
+        self.edges = set(edges)
+        self.start_concept = start_concept
+
+    def get_nodes(self):
+        return self.nodes
+
+    def get_edges(self):
+        return self.edges
+
+    def get_start_concept(self):
+        return self.start_concept
+
+    def __repr__(self) -> str:
+        parts = ["[", "Nodes", "--------------------"]
+        for n in self.nodes:
+            label = ','.join(n.get_label())
+            parts.append(f"   {n.get_number()} : {label}.")
+        parts.append("\nEdges")
+        parts.append("--------------------")
+        for e in self.edges:
+            label = ','.join(e.get_label())
+            parts.append(f"  {e.get_from_node()} --> {e.get_to_node()} : {label}.")
+        parts.append("\nStart Concept")
+        parts.append("--------------------")
+        parts.append(self.start_concept)
+        parts.append("]")
+        return "\n".join(parts)

--- a/chemlog/lopster/lopster_code/dg_generator.py
+++ b/chemlog/lopster/lopster_code/dg_generator.py
@@ -63,8 +63,9 @@ class DGGenerator:
             atom = mol.GetAtomWithIdx(i)
             label = set()
             
-            # Add element symbol (lowercase)
-            label.add(atom.GetSymbol().lower())
+            # Add element symbol (lowercase) - exclude wildcards
+            if atom.GetAtomicNum() > 0:
+                label.add(atom.GetSymbol().lower())
             
             # Add formal charge labels
             charge = atom.GetFormalCharge()

--- a/chemlog/lopster/lopster_code/dg_generator.py
+++ b/chemlog/lopster/lopster_code/dg_generator.py
@@ -1,0 +1,121 @@
+from typing import Set, Dict
+from .description_graph import DescriptionGraph
+from .node import Node
+from .edge import Edge
+from rdkit import Chem
+
+
+class DGGenerator:
+    """Builds description graph objects from molfiles using RDKit."""
+    
+    def assemble_dg_map(self, mol_list) -> Dict[str, DescriptionGraph]:
+        """
+        Produces a map of strings and description graph objects by processing 
+        the molfiles located in input_files_path. The size of the map is specified 
+        by size_of_dg_set. Discards molecules that have an R atom (radicals).
+        """
+        description_graphs = {}
+        
+        # Convert mol files into DescriptionGraph objects
+        mol_index = 0
+        while mol_index < len(mol_list):
+            try:
+                dg = self.build_description_graph(mol_list[mol_index], f"mol_{mol_index}")
+                if self.is_radical_free(dg):
+                    description_graphs[f"mol_{mol_index}"] = dg
+            except Exception as e:
+                print(f"Error processing {mol_index}: {e}")
+            mol_index += 1
+        
+        return description_graphs
+
+    def build_description_graph(self, mol: Chem.Mol, mol_index: str) -> DescriptionGraph:
+        """
+        Given a molfile path, produces a DescriptionGraph object.
+        """        
+        if mol is None:
+            raise ValueError(f"Could not parse mol: {mol_index}")
+        
+        nodes = self.retrieve_nodes(mol, mol_index)
+        edges = self.retrieve_edges(mol, mol_index)
+        
+        return DescriptionGraph(nodes, edges, mol_index)
+
+    def is_radical_free(self, dg: DescriptionGraph) -> bool:
+        """Detects whether the graph contains a node labeled with 'r' (radical)."""
+        for node in dg.get_nodes():
+            if 'r' in node.get_label():
+                return False
+        return True
+
+    def retrieve_nodes(self, mol: Chem.Mol, molecule_name: str) -> Set[Node]:
+        """Returns a set of Node objects from an RDKit molecule."""
+        nodes = set()
+        
+        # Node 0: root molecule node
+        label_zero_node = {"molecule"}
+        nodes.add(Node(0, label_zero_node))
+        
+        # Nodes 1..n: one per atom
+        number_of_atoms = mol.GetNumAtoms()
+        for i in range(number_of_atoms):
+            node_index = i + 1
+            atom = mol.GetAtomWithIdx(i)
+            label = set()
+            
+            # Add element symbol (lowercase)
+            label.add(atom.GetSymbol().lower())
+            
+            # Add formal charge labels
+            charge = atom.GetFormalCharge()
+            if charge == 1:
+                label.add("plus1")
+            elif charge == 2:
+                label.add("plus2")
+            elif charge == 3:
+                label.add("plus3")
+            elif charge == -1:
+                label.add("minus1")
+            elif charge == -2:
+                label.add("minus2")
+            elif charge == -3:
+                label.add("minus3")
+            
+            nodes.add(Node(node_index, label))
+        
+        return nodes
+
+    def retrieve_edges(self, mol: Chem.Mol, molecule_name: str) -> Set[Edge]:
+        """Returns a set of Edge objects from an RDKit molecule."""
+        edges = set()
+        
+        # Map atoms to node indices (1-based, 0 is root)
+        number_of_atoms = mol.GetNumAtoms()
+        root_node = 0
+        
+        # Add "hasAtom" edges from root to all atoms
+        label_has_atom = {"hasAtom"}
+        for i in range(number_of_atoms):
+            node_index = i + 1
+            edge = Edge(root_node, node_index, label_has_atom)
+            edges.add(edge)
+        
+        # Add bond edges (bidirectional)
+        number_of_bonds = mol.GetNumBonds()
+        for i in range(number_of_bonds):
+            bond = mol.GetBondWithIdx(i)
+            from_node = bond.GetBeginAtomIdx() + 1
+            to_node = bond.GetEndAtomIdx() + 1
+            
+            # Bond order as lowercase string
+            bond_type = bond.GetBondType()
+            bond_order = str(bond_type).lower()
+            
+            label = {bond_order}
+            edge_forward = Edge(from_node, to_node, label)
+            edge_backward = Edge(to_node, from_node, label)
+            edges.add(edge_forward)
+            edges.add(edge_backward)
+        
+        return edges
+

--- a/chemlog/lopster/lopster_code/dlv_program_manager.py
+++ b/chemlog/lopster/lopster_code/dlv_program_manager.py
@@ -1,0 +1,21 @@
+import os
+from typing import Set, List, Dict
+from .dlv_rules_generator import DLVRulesGenerator
+from .description_graph import DescriptionGraph
+from .dlv_rule import DLVRule
+from rdkit import Chem
+
+class DLVProgramManager:
+    def __init__(self, description_graphs: Dict[str, DescriptionGraph]) -> str:
+        self.description_graphs = description_graphs
+
+    # create all program files
+    def create_dlv_programs(self, mol_list: List[Chem.Mol]):
+        all_rules = set()
+        gen = DLVRulesGenerator()
+        for mol_index, mol in enumerate(mol_list):
+            dg = self.description_graphs.get(f"mol_{mol_index}")
+            if dg is not None:
+                all_rules.update(gen.translate_dg_into_rules(dg))
+        return "\n".join([rule.dlv_syntax_rule() for rule in all_rules])
+

--- a/chemlog/lopster/lopster_code/dlv_rule.py
+++ b/chemlog/lopster/lopster_code/dlv_rule.py
@@ -1,0 +1,21 @@
+from typing import List
+from .atom import Atom
+
+class DLVRule:
+    """DLV rule with head atom and optional body atoms."""
+    def __init__(self, head_atom: Atom, body_atoms: List[Atom]):
+        self.head_atom = head_atom
+        self.body_atoms = list(body_atoms)
+
+    def get_head_atom(self) -> Atom:
+        return self.head_atom
+
+    def get_body_atoms(self) -> List[Atom]:
+        return self.body_atoms
+
+    def dlv_syntax_rule(self) -> str:
+        head = self.head_atom.text_representation()
+        if not self.body_atoms:
+            return head + "."
+        body = ','.join(a.text_representation() for a in self.body_atoms)
+        return f"{head} :- {body}."

--- a/chemlog/lopster/lopster_code/dlv_rules_generator.py
+++ b/chemlog/lopster/lopster_code/dlv_rules_generator.py
@@ -1,0 +1,95 @@
+from typing import List, Set
+from .atom import Atom
+from .dlv_rule import DLVRule
+from .description_graph import DescriptionGraph
+from .node import Node
+
+class DLVRulesGenerator:
+    class GraphAtomMode:
+        FUNCTION_TERMS_ON = 1
+        VARIABLES_ON = 2
+        CONSTANTS_ON = 3
+
+    def translate_dg_into_rules(self, description_graph: DescriptionGraph) -> Set[DLVRule]:
+        rules = set()
+        rules.update(self.produce_layout_rules(description_graph, for_msa_check=False))
+        rules.add(self.produce_start_concept_fact(description_graph))
+        return rules
+
+    def produce_start_rule(self, description_graph: DescriptionGraph) -> DLVRule:
+        head = self.produce_graph_atom(description_graph, self.GraphAtomMode.FUNCTION_TERMS_ON)
+        body = [self.produce_start_atom(description_graph, "X")]
+        return DLVRule(head, body)
+
+    def produce_msa_start_rule(self, description_graph: DescriptionGraph) -> DLVRule:
+        head = self.produce_graph_atom(description_graph, self.GraphAtomMode.CONSTANTS_ON)
+        body = [self.produce_start_atom(description_graph, "X")]
+        return DLVRule(head, body)
+
+    def produce_layout_rules(self, description_graph: DescriptionGraph, for_msa_check: bool) -> Set[DLVRule]:
+        rules = set()
+        body_atoms = [self.produce_start_atom(description_graph.get_start_concept())]
+
+        for node in description_graph.get_nodes():
+            for unary_pred in node.get_label():
+                term = (self.build_constant_layout_term(description_graph.get_start_concept(), node.get_number())
+                        if for_msa_check else
+                        self.build_function_layout_term(description_graph.get_start_concept(), node.get_number()))
+                head = Atom(unary_pred, [term])
+                rules.add(DLVRule(head, body_atoms))
+
+        for edge in description_graph.get_edges():
+            for binary_pred in edge.get_label():
+                from_term = (self.build_constant_layout_term(description_graph.get_start_concept(), edge.get_from_node())
+                             if for_msa_check else
+                             self.build_function_layout_term(description_graph.get_start_concept(), edge.get_from_node()))
+                to_term = (self.build_constant_layout_term(description_graph.get_start_concept(), edge.get_to_node())
+                           if for_msa_check else
+                           self.build_function_layout_term(description_graph.get_start_concept(), edge.get_to_node()))
+                head = Atom(binary_pred, [from_term, to_term])
+                rules.add(DLVRule(head, body_atoms))
+
+        return rules
+
+    def produce_start_atom(self, start_concept_or_graph, variable: str = None) -> Atom:
+        if isinstance(start_concept_or_graph, DescriptionGraph):
+            sc = start_concept_or_graph.get_start_concept()
+        else:
+            sc = start_concept_or_graph
+        var = variable or "X"
+        return Atom(sc, [var])
+
+    def build_function_layout_term(self, start_concept: str, node_number: int) -> str:
+        if node_number != 0:
+            return f"f_{start_concept}_{node_number}(X)"
+        return "X"
+
+    def build_constant_layout_term(self, start_concept: str, node_number: int) -> str:
+        if node_number != 0:
+            return f"c_{start_concept}_{node_number}"
+        return "X"
+
+    def produce_graph_atom(self, description_graph: DescriptionGraph, graph_atom_mode: int) -> Atom:
+        pred = f"g_{description_graph.get_start_concept()}"
+        terms = []
+        if graph_atom_mode in (self.GraphAtomMode.FUNCTION_TERMS_ON, self.GraphAtomMode.CONSTANTS_ON):
+            terms.append("X")
+        elif graph_atom_mode == self.GraphAtomMode.VARIABLES_ON:
+            terms.append("Y0")
+
+        node_count = len(description_graph.get_nodes())
+        # nodes are expected to be numbered 0..n-1 but set iteration is unordered; we mimic original by using range
+        for i in range(1, node_count):
+            if graph_atom_mode == self.GraphAtomMode.FUNCTION_TERMS_ON:
+                terms.append(f"f_{description_graph.get_start_concept()}_{i}(X)")
+            elif graph_atom_mode == self.GraphAtomMode.VARIABLES_ON:
+                terms.append(f"Y{i}")
+            elif graph_atom_mode == self.GraphAtomMode.CONSTANTS_ON:
+                terms.append(f"c_{description_graph.get_start_concept()}_{i}")
+        return Atom(pred, terms)
+
+    def produce_start_concept_fact(self, description_graph: DescriptionGraph) -> DLVRule:
+        head = Atom(description_graph.get_start_concept(), [f"c_{description_graph.get_start_concept()}"])
+        return DLVRule(head, [])
+
+    # Additional MSA related methods (succession, tag, cycle detection, trans closure) can be added similarly

--- a/chemlog/lopster/lopster_code/edge.py
+++ b/chemlog/lopster/lopster_code/edge.py
@@ -1,0 +1,17 @@
+from typing import Set
+
+class Edge:
+    """Labeled directed edge from `from_node` to `to_node`."""
+    def __init__(self, from_node: int, to_node: int, label: Set[str]):
+        self.from_node = int(from_node)
+        self.to_node = int(to_node)
+        self.label = set(label)
+
+    def get_from_node(self) -> int:
+        return self.from_node
+
+    def get_to_node(self) -> int:
+        return self.to_node
+
+    def get_label(self) -> Set[str]:
+        return self.label

--- a/chemlog/lopster/lopster_code/node.py
+++ b/chemlog/lopster/lopster_code/node.py
@@ -1,0 +1,17 @@
+from typing import Set
+
+class Node:
+    """Labeled node with a number and a set of labels."""
+    def __init__(self, number: int, label: Set[str]):
+        self.number = int(number)
+        self.label = set(label)
+
+    def get_number(self) -> int:
+        return self.number
+
+    def get_label(self) -> Set[str]:
+        return self.label
+    
+    def __repr__(self):
+        label = ','.join(self.label)
+        return f"Node({self.number}: {{{label}}})"

--- a/chemlog/lopster/lopster_python.py
+++ b/chemlog/lopster/lopster_python.py
@@ -1,5 +1,5 @@
 from rdkit import Chem
-# Generated Python code from Lopster rules - this will be overwritten when calling translate_lopster.run_lopster_translation()
+# Generated Python code from Lopster rules - modified
 
 def has_bond_to(mol: Chem.Mol, so_elements, X, Y):
     # (has_bond_to(X, Y)) <=> ((bsingle(X, Y) | bdouble(X, Y) | btriple(X, Y)))
@@ -33,8 +33,9 @@ def has_bond_toAtLeast4(mol: Chem.Mol, so_elements, X):
     # (has_bond_toAtLeast4(X)) <=> (∃[Y1, Y3, Y4, Y2]: (has_bond_to(X, Y1) & has_bond_to(Y1, X) & has_bond_to(X, Y2) & has_bond_to(Y2, X) & has_bond_to(X, Y3) & has_bond_to(Y3, X) & has_bond_to(X, Y4) & has_bond_to(Y4, X) & (Y1) != (Y2) & (Y1) != (Y3) & (Y1) != (Y4) & (Y2) != (Y3) & (Y2) != (Y4) & (Y3) != (Y4)))
     return any((mol.GetBondBetweenAtoms(X.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), X.GetIdx()) is not None and (Y1 != Y2) and (Y1 != Y3) and (Y1 != Y4) and (Y2 != Y3) and (Y2 != Y4) and (Y3 != Y4)) for Y1 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y2 in mol.GetAtoms())
 
-def has_bond_toExactly2(mol: Chem.Mol, so_elements, X):
+def has_bond_toExactly2(mol: Chem.Mol, so_elements, X: Chem.Atom):
     # (has_bond_toExactly2(X)) <=> ((has_bond_toAtLeast2(X) & ~(has_bond_toAtLeast3(X))))
+    return len(X.GetNeighbors()) == 2
     return (has_bond_toAtLeast2(mol, so_elements, X) and not(has_bond_toAtLeast3(mol, so_elements, X)))
 
 def has_bond_toExactly3(mol: Chem.Mol, so_elements, X):
@@ -232,6 +233,23 @@ def monoatomic(mol: Chem.Mol, so_elements):
 
 def carboxylicAcid(mol: Chem.Mol, so_elements):
     # (carboxylicAcid()) <=> (∃[Y4, Y3, Y1, Y2]: (c(Y1) & o(Y2) & o(Y3) & horc(Y4) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & ~(midOxygen(Y3)) & ~(charged(Y3))))
+    for Y1 in mol.GetAtoms():
+        if not (Y1.GetSymbol() == 'C'):
+            continue
+        neighbors = Y1.GetNeighbors()
+        has_doubleO, has_singleO, hasHorc = False, False, False
+        for neighbor in neighbors:
+            if neighbor.GetSymbol() == 'O' and mol.GetBondBetweenAtoms(Y1.GetIdx(), neighbor.GetIdx()) is not None:
+                bond = mol.GetBondBetweenAtoms(Y1.GetIdx(), neighbor.GetIdx())
+                if bond.GetBondType() == Chem.BondType.DOUBLE:
+                    has_doubleO = True
+                elif bond.GetBondType() == Chem.BondType.SINGLE and not(midOxygen(mol, so_elements, neighbor)) and not(charged(mol, so_elements, neighbor)):
+                    has_singleO = True
+            elif horc(mol, so_elements, neighbor):
+                hasHorc = True
+        if has_doubleO and has_singleO and hasHorc:
+            return True
+    return False
     return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'O' and horc(mol, so_elements, Y4) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(midOxygen(mol, so_elements, Y3)) and not(charged(mol, so_elements, Y3))) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
 
 def atLeast2CarboxyGroups(mol: Chem.Mol, so_elements):
@@ -252,6 +270,8 @@ def exactly2CarboxyGroups(mol: Chem.Mol, so_elements):
 
 def carboxylicEster(mol: Chem.Mol, so_elements):
     # (carboxylicEster()) <=> (∃[Y1, Y3, Y5, Y4, Y2]: (c(Y1) & o(Y2) & o(Y3) & c(Y4) & horc(Y5) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y5) & bsingle(Y5, Y1) & bsingle(Y3, Y4) & bsingle(Y4, Y3)))
+    # smarts
+    return Chem.QuickSmartsMatch(Chem.MolToSmiles(mol), "[#6]=[#8](-[#8]-[#6])-[#6,#1]")
     return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'O' and Y4.GetSymbol() == 'C' and horc(mol, so_elements, Y5) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE)) for Y1 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y5 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y2 in mol.GetAtoms())
 
 def hasBenzeneRing(mol: Chem.Mol, so_elements):
@@ -264,11 +284,32 @@ def hasFourMemberedRing(mol: Chem.Mol, so_elements):
 
 def amine(mol: Chem.Mol, so_elements):
     # (amine()) <=> (∃[Y4, Y3, Y1, Y2]: (n(Y1) & has_bond_to1to3(Y1) & horc(Y2) & horc(Y3) & c(Y4) & bsingle(Y1, Y2) & bsingle(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & ~(acylCarbon(Y2)) & ~(acylCarbon(Y3)) & ~(acylCarbon(Y4)) & (Y2) != (Y3) & (Y2) != (Y4) & (Y3) != (Y4)))
-    return any((Y1.GetSymbol() == 'N' and has_bond_to1to3(mol, so_elements, Y1) and horc(mol, so_elements, Y2) and horc(mol, so_elements, Y3) and Y4.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(acylCarbon(mol, so_elements, Y2)) and not(acylCarbon(mol, so_elements, Y3)) and not(acylCarbon(mol, so_elements, Y4)) and (Y2 != Y3) and (Y2 != Y4) and (Y3 != Y4)) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+    for Y1 in mol.GetAtoms():
+        if not (Y1.GetSymbol() == 'N'):
+            continue
+        if not has_bond_to1to3(mol, so_elements, Y1):
+            continue
+        if any((horc(mol, so_elements, Y2) and horc(mol, so_elements, Y3) and Y4.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(acylCarbon(mol, so_elements, Y2)) and not(acylCarbon(mol, so_elements, Y3)) and not(acylCarbon(mol, so_elements, Y4)) and (Y2 != Y3) and (Y2 != Y4) and (Y3 != Y4)) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y2 in mol.GetAtoms()):
+            return True
+    return False
 
 def aldehyde(mol: Chem.Mol, so_elements):
     # (aldehyde()) <=> (∃[Y3, Y1, Y2]: (c(Y1) & has_bond_toExactly2(Y1) & o(Y2) & horc(Y3) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1)))
-    return any((Y1.GetSymbol() == 'C' and has_bond_toExactly2(mol, so_elements, Y1) and Y2.GetSymbol() == 'O' and horc(mol, so_elements, Y3) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE)) for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+    for Y1 in mol.GetAtoms():
+        if not (Y1.GetSymbol() == 'C'):
+            continue
+        if not has_bond_toExactly2(mol, so_elements, Y1):
+            continue
+        neighbors = Y1.GetNeighbors()
+        assert len(neighbors) == 2
+        for [Y2, Y3] in [(neighbors[0], neighbors[1]), (neighbors[1], neighbors[0])]:
+            if not (Y2.GetSymbol() == 'O'):
+                continue
+            if not horc(mol, so_elements, Y3):
+                continue
+            if (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE):
+                return True
+    return False
 
 def cyclic(mol: Chem.Mol, so_elements):
     # (cyclic()) <=> (∃[Y]: (closedLoopAtLeast3(Y)))
@@ -276,6 +317,18 @@ def cyclic(mol: Chem.Mol, so_elements):
 
 def ketone(mol: Chem.Mol, so_elements):
     # (ketone()) <=> (∃[Y4, Y3, Y1, Y2]: (c(Y1) & o(Y2) & c(Y3) & c(Y4) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & (Y3) != (Y4)))
+    for Y1 in mol.GetAtoms():
+        if not (Y1.GetSymbol() == "C"):
+            continue
+        neighbors = Y1.GetNeighbors()
+        o_count = [n for n in neighbors if n.GetSymbol() == "O" and (mol.GetBondBetweenAtoms(Y1.GetIdx(), n.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), n.GetIdx()).GetBondType() == Chem.BondType.DOUBLE)]
+        if len(o_count) < 1:
+            continue
+        c_count = [n for n in neighbors if n.GetSymbol() == "C" and (mol.GetBondBetweenAtoms(Y1.GetIdx(), n.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), n.GetIdx()).GetBondType() == Chem.BondType.SINGLE)]
+        if len(c_count) < 2:
+            continue
+        return True
+    return False
     return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'C' and Y4.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (Y3 != Y4)) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
 
 def unsaturated(mol: Chem.Mol, so_elements):
@@ -301,3 +354,9 @@ def haloAlkane(mol: Chem.Mol, so_elements):
 def heteroOrganic(mol: Chem.Mol, so_elements):
     # (heteroOrganic()) <=> (∃[Y1, Y2]: (c(Y1) & ~(c(Y2)) & ~(h(Y2)) & has_bond_to(Y1, Y2) & has_bond_to(Y2, Y1)))
     return any((Y1.GetSymbol() == 'C' and not(Y2.GetSymbol() == 'C') and not(Y2.GetSymbol() == 'H') and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+if __name__ == "__main__":
+    mol = Chem.MolFromSmiles(r"[Cl-].[H][N+](C)(C)CC\C=C1\c2ccccc2CSc2ccccc12")
+    for atom in mol.GetAtoms():
+        print(f"Atom: {atom.GetIdx()} {atom.GetSymbol()}")
+        print(has_bond_to1to3(mol, [], atom))

--- a/chemlog/lopster/lopster_python.py
+++ b/chemlog/lopster/lopster_python.py
@@ -1,0 +1,303 @@
+from rdkit import Chem
+# Generated Python code from Lopster rules - this will be overwritten when calling translate_lopster.run_lopster_translation()
+
+def has_bond_to(mol: Chem.Mol, so_elements, X, Y):
+    # (has_bond_to(X, Y)) <=> ((bsingle(X, Y) | bdouble(X, Y) | btriple(X, Y)))
+    return ((mol.GetBondBetweenAtoms(X.GetIdx(), Y.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y.GetIdx()).GetBondType() == Chem.BondType.SINGLE) or (mol.GetBondBetweenAtoms(X.GetIdx(), Y.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) or (mol.GetBondBetweenAtoms(X.GetIdx(), Y.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y.GetIdx()).GetBondType() == Chem.BondType.TRIPLE))
+
+def horc(mol: Chem.Mol, so_elements, X):
+    # (horc(X)) <=> ((h(X) | c(X)))
+    return (X.GetSymbol() == 'H' or X.GetSymbol() == 'C')
+
+def charged(mol: Chem.Mol, so_elements, X):
+    # (charged(X)) <=> ((charge3(X) | charge2(X) | charge1(X) | charge_m3(X) | charge_m2(X) | charge_m1(X)))
+    return (X.GetFormalCharge() == 3 or X.GetFormalCharge() == 2 or X.GetFormalCharge() == 1 or X.GetFormalCharge() == -3 or X.GetFormalCharge() == -2 or X.GetFormalCharge() == -1)
+
+def midOxygen(mol: Chem.Mol, so_elements, Y):
+    # (midOxygen(Y)) <=> (∃[X, Y1, Y2]: (o(Y) & has_bond_to(Y, Y1) & has_bond_to(Y1, Y) & has_bond_to(Y, Y2) & has_bond_to(Y2, Y) & (Y1) != (Y2)))
+    return any((Y.GetSymbol() == 'O' and mol.GetBondBetweenAtoms(Y.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y.GetIdx()) is not None and (Y1 != Y2)) for X in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def has_bond_toAtLeast1(mol: Chem.Mol, so_elements, X):
+    # (has_bond_toAtLeast1(X)) <=> (∃[Y1]: (has_bond_to(X, Y1) & has_bond_to(Y1, X)))
+    return any((mol.GetBondBetweenAtoms(X.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), X.GetIdx()) is not None) for Y1 in mol.GetAtoms())
+
+def has_bond_toAtLeast2(mol: Chem.Mol, so_elements, X):
+    # (has_bond_toAtLeast2(X)) <=> (∃[Y1, Y2]: (has_bond_to(X, Y1) & has_bond_to(Y1, X) & has_bond_to(X, Y2) & has_bond_to(Y2, X) & (Y1) != (Y2)))
+    return any((mol.GetBondBetweenAtoms(X.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), X.GetIdx()) is not None and (Y1 != Y2)) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def has_bond_toAtLeast3(mol: Chem.Mol, so_elements, X):
+    # (has_bond_toAtLeast3(X)) <=> (∃[Y3, Y1, Y2]: (has_bond_to(X, Y1) & has_bond_to(Y1, X) & has_bond_to(X, Y2) & has_bond_to(Y2, X) & has_bond_to(X, Y3) & has_bond_to(Y3, X) & (Y1) != (Y2) & (Y1) != (Y3) & (Y2) != (Y3)))
+    return any((mol.GetBondBetweenAtoms(X.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), X.GetIdx()) is not None and (Y1 != Y2) and (Y1 != Y3) and (Y2 != Y3)) for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def has_bond_toAtLeast4(mol: Chem.Mol, so_elements, X):
+    # (has_bond_toAtLeast4(X)) <=> (∃[Y1, Y3, Y4, Y2]: (has_bond_to(X, Y1) & has_bond_to(Y1, X) & has_bond_to(X, Y2) & has_bond_to(Y2, X) & has_bond_to(X, Y3) & has_bond_to(Y3, X) & has_bond_to(X, Y4) & has_bond_to(Y4, X) & (Y1) != (Y2) & (Y1) != (Y3) & (Y1) != (Y4) & (Y2) != (Y3) & (Y2) != (Y4) & (Y3) != (Y4)))
+    return any((mol.GetBondBetweenAtoms(X.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), X.GetIdx()) is not None and (Y1 != Y2) and (Y1 != Y3) and (Y1 != Y4) and (Y2 != Y3) and (Y2 != Y4) and (Y3 != Y4)) for Y1 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def has_bond_toExactly2(mol: Chem.Mol, so_elements, X):
+    # (has_bond_toExactly2(X)) <=> ((has_bond_toAtLeast2(X) & ~(has_bond_toAtLeast3(X))))
+    return (has_bond_toAtLeast2(mol, so_elements, X) and not(has_bond_toAtLeast3(mol, so_elements, X)))
+
+def has_bond_toExactly3(mol: Chem.Mol, so_elements, X):
+    # (has_bond_toExactly3(X)) <=> ((has_bond_toAtLeast3(X) & ~(has_bond_toAtLeast4(X))))
+    return (has_bond_toAtLeast3(mol, so_elements, X) and not(has_bond_toAtLeast4(mol, so_elements, X)))
+
+def has_bond_to1to3(mol: Chem.Mol, so_elements, X):
+    # (has_bond_to1to3(X)) <=> ((has_bond_toAtLeast1(X) & ~(has_bond_toAtLeast4(X))))
+    return (has_bond_toAtLeast1(mol, so_elements, X) and not(has_bond_toAtLeast4(mol, so_elements, X)))
+
+def acylCarbon(mol: Chem.Mol, so_elements, Y):
+    # (acylCarbon(Y)) <=> (∃[X, Z]: (c(Y) & o(Z) & bdouble(Y, Z) & bdouble(Z, Y)))
+    return any((Y.GetSymbol() == 'C' and Z.GetSymbol() == 'O' and (mol.GetBondBetweenAtoms(Y.GetIdx(), Z.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y.GetIdx(), Z.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Z.GetIdx(), Y.GetIdx()) is not None and mol.GetBondBetweenAtoms(Z.GetIdx(), Y.GetIdx()).GetBondType() == Chem.BondType.DOUBLE)) for X in mol.GetAtoms() for Z in mol.GetAtoms())
+
+def noble(mol: Chem.Mol, so_elements, X):
+    # (noble(X)) <=> ((ar(X) | he(X) | kr(X) | ne(X) | rn(X) | xe(X)))
+    return (X.GetSymbol() == 'Ar' or X.GetSymbol() == 'He' or X.GetSymbol() == 'Kr' or X.GetSymbol() == 'Ne' or X.GetSymbol() == 'Rn' or X.GetSymbol() == 'Xe')
+
+def cleanReachable(mol: Chem.Mol, so_elements, X, Z, W):
+    # (cleanReachable(X, Z, W)) <=> (∃[Y]: (cleanReachable(X, Y, Z) & has_bond_to(Z, W) & has_bond_to(W, Z) & (X) != (W) & (Y) != (W) & (W) != (Z)))
+    return any((cleanReachable(mol, so_elements, X, Y, Z) and mol.GetBondBetweenAtoms(Z.GetIdx(), W.GetIdx()) is not None and mol.GetBondBetweenAtoms(W.GetIdx(), Z.GetIdx()) is not None and (X != W) and (Y != W) and (W != Z)) for Y in mol.GetAtoms())
+
+def closedLoopAtLeast3(mol: Chem.Mol, so_elements, X):
+    # (closedLoopAtLeast3(X)) <=> (∃[Z, Y]: (cleanReachable(X, Y, Z) & has_bond_to(Z, X) & has_bond_to(X, Z)))
+    return any((cleanReachable(mol, so_elements, X, Y, Z) and mol.GetBondBetweenAtoms(Z.GetIdx(), X.GetIdx()) is not None and mol.GetBondBetweenAtoms(X.GetIdx(), Z.GetIdx()) is not None) for Z in mol.GetAtoms() for Y in mol.GetAtoms())
+
+def halogen(mol: Chem.Mol, so_elements, X):
+    # (halogen(X)) <=> ((f(X) | cl(X) | br(X) | i(X) | at(X)))
+    return (X.GetSymbol() == 'F' or X.GetSymbol() == 'Cl' or X.GetSymbol() == 'Br' or X.GetSymbol() == 'I' or X.GetSymbol() == 'At')
+
+
+def astatineMolEntity(mol: Chem.Mol, so_elements):
+    # (astatineMolEntity()) <=> (∃[Y]: (at(Y)))
+    return any(Y.GetSymbol() == 'At' for Y in mol.GetAtoms())
+
+def bromineMolEntity(mol: Chem.Mol, so_elements):
+    # (bromineMolEntity()) <=> (∃[Y]: (br(Y)))
+    return any(Y.GetSymbol() == 'Br' for Y in mol.GetAtoms())
+
+def chlorineMolEntity(mol: Chem.Mol, so_elements):
+    # (chlorineMolEntity()) <=> (∃[Y]: (cl(Y)))
+    return any(Y.GetSymbol() == 'Cl' for Y in mol.GetAtoms())
+
+def fluorineMolEntity(mol: Chem.Mol, so_elements):
+    # (fluorineMolEntity()) <=> (∃[Y]: (f(Y)))
+    return any(Y.GetSymbol() == 'F' for Y in mol.GetAtoms())
+
+def iodineMolEntity(mol: Chem.Mol, so_elements):
+    # (iodineMolEntity()) <=> (∃[Y]: (i(Y)))
+    return any(Y.GetSymbol() == 'I' for Y in mol.GetAtoms())
+
+def halogenMolEntity(mol: Chem.Mol, so_elements):
+    # (halogenMolEntity()) <=> ((bromineMolEntity() | chlorineMolEntity() | fluorineMolEntity() | astatineMolEntity() | iodineMolEntity()))
+    return (bromineMolEntity(mol, so_elements, ) or chlorineMolEntity(mol, so_elements, ) or fluorineMolEntity(mol, so_elements, ) or astatineMolEntity(mol, so_elements, ) or iodineMolEntity(mol, so_elements, ))
+
+def poloniumMolEntity(mol: Chem.Mol, so_elements):
+    # (poloniumMolEntity()) <=> (∃[Y]: (po(Y)))
+    return any(Y.GetSymbol() == 'Po' for Y in mol.GetAtoms())
+
+def seleniumMolEntity(mol: Chem.Mol, so_elements):
+    # (seleniumMolEntity()) <=> (∃[Y]: (se(Y)))
+    return any(Y.GetSymbol() == 'Se' for Y in mol.GetAtoms())
+
+def sulfurMolEntity(mol: Chem.Mol, so_elements):
+    # (sulfurMolEntity()) <=> (∃[Y]: (s(Y)))
+    return any(Y.GetSymbol() == 'S' for Y in mol.GetAtoms())
+
+def telluriumMolEntity(mol: Chem.Mol, so_elements):
+    # (telluriumMolEntity()) <=> (∃[Y]: (te(Y)))
+    return any(Y.GetSymbol() == 'Te' for Y in mol.GetAtoms())
+
+def chalcogenMolEntity(mol: Chem.Mol, so_elements):
+    # (chalcogenMolEntity()) <=> ((oxygenMolEntity() | poloniumMolEntity() | seleniumMolEntity() | sulfurMolEntity() | telluriumMolEntity()))
+    return (oxygenMolEntity(mol, so_elements, ) or poloniumMolEntity(mol, so_elements, ) or seleniumMolEntity(mol, so_elements, ) or sulfurMolEntity(mol, so_elements, ) or telluriumMolEntity(mol, so_elements, ))
+
+def antimonyMolEntity(mol: Chem.Mol, so_elements):
+    # (antimonyMolEntity()) <=> (∃[Y]: (sb(Y)))
+    return any(Y.GetSymbol() == 'Sb' for Y in mol.GetAtoms())
+
+def arsenicMolEntity(mol: Chem.Mol, so_elements):
+    # (arsenicMolEntity()) <=> (∃[Y]: (as(Y)))
+    return any(Y.GetSymbol() == 'As' for Y in mol.GetAtoms())
+
+def bismuthMolEntity(mol: Chem.Mol, so_elements):
+    # (bismuthMolEntity()) <=> (∃[Y]: (bi(Y)))
+    return any(Y.GetSymbol() == 'Bi' for Y in mol.GetAtoms())
+
+def nitrogenMolEntity(mol: Chem.Mol, so_elements):
+    # (nitrogenMolEntity()) <=> (∃[Y]: (ni(Y)))
+    return any(Y.GetSymbol() == 'Ni' for Y in mol.GetAtoms())
+
+def pnictogenMolEntity(mol: Chem.Mol, so_elements):
+    # (pnictogenMolEntity()) <=> ((antimonyMolEntity() | arsenicMolEntity() | bismuthMolEntity() | nitrogenMolEntity() | phosphorusMolEntity()))
+    return (antimonyMolEntity(mol, so_elements, ) or arsenicMolEntity(mol, so_elements, ) or bismuthMolEntity(mol, so_elements, ) or nitrogenMolEntity(mol, so_elements, ) or phosphorusMolEntity(mol, so_elements, ))
+
+def chromiumMolEntity(mol: Chem.Mol, so_elements):
+    # (chromiumMolEntity()) <=> (∃[Y]: (cr(Y)))
+    return any(Y.GetSymbol() == 'Cr' for Y in mol.GetAtoms())
+
+def molybdenumMolEntity(mol: Chem.Mol, so_elements):
+    # (molybdenumMolEntity()) <=> (∃[Y]: (mo(Y)))
+    return any(Y.GetSymbol() == 'Mo' for Y in mol.GetAtoms())
+
+def seaborgiumMolEntity(mol: Chem.Mol, so_elements):
+    # (seaborgiumMolEntity()) <=> (∃[Y]: (sg(Y)))
+    return any(Y.GetSymbol() == 'Sg' for Y in mol.GetAtoms())
+
+def tungstenMolEntity(mol: Chem.Mol, so_elements):
+    # (tungstenMolEntity()) <=> (∃[Y]: (w(Y)))
+    return any(Y.GetSymbol() == 'W' for Y in mol.GetAtoms())
+
+def chromiumGroupMolEntity(mol: Chem.Mol, so_elements):
+    # (chromiumGroupMolEntity()) <=> ((chromiumMolEntity() | molybdenumMolEntity() | seaborgiumMolEntity() | tungstenMolEntity()))
+    return (chromiumMolEntity(mol, so_elements, ) or molybdenumMolEntity(mol, so_elements, ) or seaborgiumMolEntity(mol, so_elements, ) or tungstenMolEntity(mol, so_elements, ))
+
+def nobleGasMolEntity(mol: Chem.Mol, so_elements):
+    # (nobleGasMolEntity()) <=> (∃[Y]: (noble(Y)))
+    return any(noble(mol, so_elements, Y) for Y in mol.GetAtoms())
+
+def carbonMolEntity(mol: Chem.Mol, so_elements):
+    # (carbonMolEntity()) <=> (∃[Y]: (c(Y)))
+    return any(Y.GetSymbol() == 'C' for Y in mol.GetAtoms())
+
+def oxygenMolEntity(mol: Chem.Mol, so_elements):
+    # (oxygenMolEntity()) <=> (∃[Y]: (o(Y)))
+    return any(Y.GetSymbol() == 'O' for Y in mol.GetAtoms())
+
+def hydrogenMolEntity(mol: Chem.Mol, so_elements):
+    # (hydrogenMolEntity()) <=> (∃[Y]: (h(Y)))
+    return any(Y.GetSymbol() == 'H' for Y in mol.GetAtoms())
+
+def phosphorusMolEntity(mol: Chem.Mol, so_elements):
+    # (phosphorusMolEntity()) <=> (∃[Y]: (p(Y)))
+    return any(Y.GetSymbol() == 'P' for Y in mol.GetAtoms())
+
+def inorganic(mol: Chem.Mol, so_elements):
+    # (inorganic()) <=> ((~(carbonMolEntity())))
+    return not(carbonMolEntity(mol, so_elements, ))
+
+def notHydroCarbon(mol: Chem.Mol, so_elements):
+    # (notHydroCarbon()) <=> (∃[Y]: (~(c(Y)) & ~(h(Y))))
+    return any((not(Y.GetSymbol() == 'C') and not(Y.GetSymbol() == 'H')) for Y in mol.GetAtoms())
+
+def hydroCarbon(mol: Chem.Mol, so_elements):
+    # (hydroCarbon()) <=> ((carbonMolEntity() & ~(notHydroCarbon())))
+    return (carbonMolEntity(mol, so_elements, ) and not(notHydroCarbon(mol, so_elements, )))
+
+def notHaloHydroCarbon(mol: Chem.Mol, so_elements):
+    # (notHaloHydroCarbon()) <=> (∃[Y]: (~(c(Y)) & ~(h(Y)) & ~(halogen(Y))))
+    return any((not(Y.GetSymbol() == 'C') and not(Y.GetSymbol() == 'H') and not(halogen(mol, so_elements, Y))) for Y in mol.GetAtoms())
+
+def haloHydroCarbon(mol: Chem.Mol, so_elements):
+    # (haloHydroCarbon()) <=> ((carbonMolEntity() & halogenMolEntity() & ~(notHaloHydroCarbon())))
+    return (carbonMolEntity(mol, so_elements, ) and halogenMolEntity(mol, so_elements, ) and not(notHaloHydroCarbon(mol, so_elements, )))
+
+def atLeast2Carbons(mol: Chem.Mol, so_elements):
+    # (atLeast2Carbons()) <=> (∃[Y1, Y2]: (c(Y1) & c(Y2) & (Y1) != (Y2)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'C' and (Y1 != Y2)) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def exactly1Carbon(mol: Chem.Mol, so_elements):
+    # (exactly1Carbon()) <=> ((carbonMolEntity() & ~(atLeast2Carbons())))
+    return (carbonMolEntity(mol, so_elements, ) and not(atLeast2Carbons(mol, so_elements, )))
+
+def atLeast3Carbons(mol: Chem.Mol, so_elements):
+    # (atLeast3Carbons()) <=> (∃[Y3, Y1, Y2]: (c(Y1) & c(Y2) & (Y1) != (Y2) & c(Y3) & (Y1) != (Y3) & (Y2) != (Y3)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'C' and (Y1 != Y2) and Y3.GetSymbol() == 'C' and (Y1 != Y3) and (Y2 != Y3)) for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def exactly2Carbons(mol: Chem.Mol, so_elements):
+    # (exactly2Carbons()) <=> ((atLeast2Carbons() & ~(atLeast3Carbons())))
+    return (atLeast2Carbons(mol, so_elements, ) and not(atLeast3Carbons(mol, so_elements, )))
+
+def atLeast4Carbons(mol: Chem.Mol, so_elements):
+    # (atLeast4Carbons()) <=> (∃[Y4, Y3, Y1, Y2]: (c(Y1) & c(Y2) & (Y1) != (Y2) & c(Y3) & (Y1) != (Y3) & (Y2) != (Y3) & c(Y4) & (Y1) != (Y4) & (Y2) != (Y4) & (Y3) != (Y4)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'C' and (Y1 != Y2) and Y3.GetSymbol() == 'C' and (Y1 != Y3) and (Y2 != Y3) and Y4.GetSymbol() == 'C' and (Y1 != Y4) and (Y2 != Y4) and (Y3 != Y4)) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def exactly3Carbons(mol: Chem.Mol, so_elements):
+    # (exactly3Carbons()) <=> ((atLeast3Carbons() & ~(atLeast4Carbons())))
+    return (atLeast3Carbons(mol, so_elements, ) and not(atLeast4Carbons(mol, so_elements, )))
+
+def atLeast5Carbons(mol: Chem.Mol, so_elements):
+    # (atLeast5Carbons()) <=> (∃[Y1, Y3, Y5, Y4, Y2]: (c(Y1) & c(Y2) & (Y1) != (Y2) & c(Y3) & (Y1) != (Y3) & (Y2) != (Y3) & c(Y4) & (Y1) != (Y4) & (Y2) != (Y4) & (Y3) != (Y4) & c(Y5) & (Y1) != (Y5) & (Y2) != (Y5) & (Y3) != (Y5) & (Y4) != (Y5)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'C' and (Y1 != Y2) and Y3.GetSymbol() == 'C' and (Y1 != Y3) and (Y2 != Y3) and Y4.GetSymbol() == 'C' and (Y1 != Y4) and (Y2 != Y4) and (Y3 != Y4) and Y5.GetSymbol() == 'C' and (Y1 != Y5) and (Y2 != Y5) and (Y3 != Y5) and (Y4 != Y5)) for Y1 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y5 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def exactly4Carbons(mol: Chem.Mol, so_elements):
+    # (exactly4Carbons()) <=> ((atLeast4Carbons() & ~(atLeast5Carbons())))
+    return (atLeast4Carbons(mol, so_elements, ) and not(atLeast5Carbons(mol, so_elements, )))
+
+def polyatomic(mol: Chem.Mol, so_elements):
+    # (polyatomic()) <=> (∃[Y1, Y2]: ((Y1) != (Y2)))
+    return any((Y1 != Y2) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def monoatomic(mol: Chem.Mol, so_elements):
+    # (monoatomic()) <=> (∃[Y1]: (~(polyatomic())))
+    return any(not(polyatomic(mol, so_elements, )) for Y1 in mol.GetAtoms())
+
+def carboxylicAcid(mol: Chem.Mol, so_elements):
+    # (carboxylicAcid()) <=> (∃[Y4, Y3, Y1, Y2]: (c(Y1) & o(Y2) & o(Y3) & horc(Y4) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & ~(midOxygen(Y3)) & ~(charged(Y3))))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'O' and horc(mol, so_elements, Y4) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(midOxygen(mol, so_elements, Y3)) and not(charged(mol, so_elements, Y3))) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def atLeast2CarboxyGroups(mol: Chem.Mol, so_elements):
+    # (atLeast2CarboxyGroups()) <=> (∃[Y1, Y3, Y8, Y5, Y4, Y7, Y6, Y2]: (c(Y1) & o(Y2) & o(Y3) & horc(Y4) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & ~(midOxygen(Y3)) & ~(charged(Y3)) & c(Y5) & o(Y6) & o(Y7) & horc(Y8) & bdouble(Y5, Y6) & bdouble(Y6, Y5) & bsingle(Y5, Y7) & bsingle(Y7, Y5) & bsingle(Y5, Y8) & bsingle(Y8, Y5) & ~(midOxygen(Y7)) & ~(charged(Y7)) & (Y1) != (Y5)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'O' and horc(mol, so_elements, Y4) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(midOxygen(mol, so_elements, Y3)) and not(charged(mol, so_elements, Y3)) and Y5.GetSymbol() == 'C' and Y6.GetSymbol() == 'O' and Y7.GetSymbol() == 'O' and horc(mol, so_elements, Y8) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y6.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y6.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y6.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y6.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y7.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y7.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y7.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y7.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y8.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y8.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y8.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y8.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(midOxygen(mol, so_elements, Y7)) and not(charged(mol, so_elements, Y7)) and (Y1 != Y5)) for Y1 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y8 in mol.GetAtoms() for Y5 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y7 in mol.GetAtoms() for Y6 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def exactly1CarboxyGroup(mol: Chem.Mol, so_elements):
+    # (exactly1CarboxyGroup()) <=> ((carboxylicAcid() & ~(atLeast2CarboxyGroups())))
+    return (carboxylicAcid(mol, so_elements, ) and not(atLeast2CarboxyGroups(mol, so_elements, )))
+
+def atLeast3CarboxyGroups(mol: Chem.Mol, so_elements):
+    # (atLeast3CarboxyGroups()) <=> (∃[Y1, Y9, Y3, Y8, Y10, Y5, Y11, Y4, Y7, Y12, Y6, Y2]: (c(Y1) & o(Y2) & o(Y3) & horc(Y4) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & ~(midOxygen(Y3)) & ~(charged(Y3)) & c(Y5) & o(Y6) & o(Y7) & horc(Y8) & bdouble(Y5, Y6) & bdouble(Y6, Y5) & bsingle(Y5, Y7) & bsingle(Y7, Y5) & bsingle(Y5, Y8) & bsingle(Y8, Y5) & ~(midOxygen(Y7)) & ~(charged(Y7)) & c(Y9) & o(Y10) & o(Y11) & horc(Y12) & bdouble(Y9, Y10) & bdouble(Y10, Y9) & bsingle(Y9, Y11) & bsingle(Y11, Y9) & bsingle(Y9, Y12) & bsingle(Y12, Y9) & ~(midOxygen(Y11)) & ~(charged(Y11)) & (Y1) != (Y5) & (Y9) != (Y5) & (Y9) != (Y1)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'O' and horc(mol, so_elements, Y4) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(midOxygen(mol, so_elements, Y3)) and not(charged(mol, so_elements, Y3)) and Y5.GetSymbol() == 'C' and Y6.GetSymbol() == 'O' and Y7.GetSymbol() == 'O' and horc(mol, so_elements, Y8) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y6.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y6.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y6.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y6.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y7.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y7.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y7.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y7.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y8.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y8.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y8.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y8.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(midOxygen(mol, so_elements, Y7)) and not(charged(mol, so_elements, Y7)) and Y9.GetSymbol() == 'C' and Y10.GetSymbol() == 'O' and Y11.GetSymbol() == 'O' and horc(mol, so_elements, Y12) and (mol.GetBondBetweenAtoms(Y9.GetIdx(), Y10.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y9.GetIdx(), Y10.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y10.GetIdx(), Y9.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y10.GetIdx(), Y9.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y9.GetIdx(), Y11.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y9.GetIdx(), Y11.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y11.GetIdx(), Y9.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y11.GetIdx(), Y9.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y9.GetIdx(), Y12.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y9.GetIdx(), Y12.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y12.GetIdx(), Y9.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y12.GetIdx(), Y9.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(midOxygen(mol, so_elements, Y11)) and not(charged(mol, so_elements, Y11)) and (Y1 != Y5) and (Y9 != Y5) and (Y9 != Y1)) for Y1 in mol.GetAtoms() for Y9 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y8 in mol.GetAtoms() for Y10 in mol.GetAtoms() for Y5 in mol.GetAtoms() for Y11 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y7 in mol.GetAtoms() for Y12 in mol.GetAtoms() for Y6 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def exactly2CarboxyGroups(mol: Chem.Mol, so_elements):
+    # (exactly2CarboxyGroups()) <=> ((atLeast2CarboxyGroups() & ~(atLeast3CarboxyGroups())))
+    return (atLeast2CarboxyGroups(mol, so_elements, ) and not(atLeast3CarboxyGroups(mol, so_elements, )))
+
+def carboxylicEster(mol: Chem.Mol, so_elements):
+    # (carboxylicEster()) <=> (∃[Y1, Y3, Y5, Y4, Y2]: (c(Y1) & o(Y2) & o(Y3) & c(Y4) & horc(Y5) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y5) & bsingle(Y5, Y1) & bsingle(Y3, Y4) & bsingle(Y4, Y3)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'O' and Y4.GetSymbol() == 'C' and horc(mol, so_elements, Y5) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE)) for Y1 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y5 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def hasBenzeneRing(mol: Chem.Mol, so_elements):
+    # (hasBenzeneRing()) <=> (∃[Y1, Y3, Y5, Y4, Y6, Y2]: (c(Y1) & c(Y2) & bsingle(Y1, Y2) & bsingle(Y2, Y1) & c(Y3) & bdouble(Y2, Y3) & bdouble(Y3, Y2) & c(Y4) & bsingle(Y3, Y4) & bsingle(Y4, Y3) & bdouble(Y4, Y5) & bdouble(Y5, Y4) & c(Y5) & c(Y6) & bsingle(Y5, Y6) & bsingle(Y6, Y5) & bdouble(Y6, Y1) & bdouble(Y1, Y6)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and Y3.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and Y4.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and Y5.GetSymbol() == 'C' and Y6.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y5.GetIdx(), Y6.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y5.GetIdx(), Y6.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y6.GetIdx(), Y5.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y6.GetIdx(), Y5.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y6.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y6.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y6.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y6.GetIdx()).GetBondType() == Chem.BondType.DOUBLE)) for Y1 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y5 in mol.GetAtoms() for Y4 in mol.GetAtoms() for Y6 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def hasFourMemberedRing(mol: Chem.Mol, so_elements):
+    # (hasFourMemberedRing()) <=> (∃[Y4, Y3, Y1, Y2]: ((Y1) != (Y2) & has_bond_to(Y1, Y2) & has_bond_to(Y2, Y1) & (Y1) != (Y3) & (Y2) != (Y3) & has_bond_to(Y2, Y3) & has_bond_to(Y3, Y2) & (Y1) != (Y4) & (Y2) != (Y4) & (Y3) != (Y4) & has_bond_to(Y3, Y4) & has_bond_to(Y4, Y3) & has_bond_to(Y4, Y1) & has_bond_to(Y1, Y4)))
+    return any(((Y1 != Y2) and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and (Y1 != Y3) and (Y2 != Y3) and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y2.GetIdx()) is not None and (Y1 != Y4) and (Y2 != Y4) and (Y3 != Y4) and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def amine(mol: Chem.Mol, so_elements):
+    # (amine()) <=> (∃[Y4, Y3, Y1, Y2]: (n(Y1) & has_bond_to1to3(Y1) & horc(Y2) & horc(Y3) & c(Y4) & bsingle(Y1, Y2) & bsingle(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & ~(acylCarbon(Y2)) & ~(acylCarbon(Y3)) & ~(acylCarbon(Y4)) & (Y2) != (Y3) & (Y2) != (Y4) & (Y3) != (Y4)))
+    return any((Y1.GetSymbol() == 'N' and has_bond_to1to3(mol, so_elements, Y1) and horc(mol, so_elements, Y2) and horc(mol, so_elements, Y3) and Y4.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and not(acylCarbon(mol, so_elements, Y2)) and not(acylCarbon(mol, so_elements, Y3)) and not(acylCarbon(mol, so_elements, Y4)) and (Y2 != Y3) and (Y2 != Y4) and (Y3 != Y4)) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def aldehyde(mol: Chem.Mol, so_elements):
+    # (aldehyde()) <=> (∃[Y3, Y1, Y2]: (c(Y1) & has_bond_toExactly2(Y1) & o(Y2) & horc(Y3) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1)))
+    return any((Y1.GetSymbol() == 'C' and has_bond_toExactly2(mol, so_elements, Y1) and Y2.GetSymbol() == 'O' and horc(mol, so_elements, Y3) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE)) for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def cyclic(mol: Chem.Mol, so_elements):
+    # (cyclic()) <=> (∃[Y]: (closedLoopAtLeast3(Y)))
+    return any(closedLoopAtLeast3(mol, so_elements, Y) for Y in mol.GetAtoms())
+
+def ketone(mol: Chem.Mol, so_elements):
+    # (ketone()) <=> (∃[Y4, Y3, Y1, Y2]: (c(Y1) & o(Y2) & c(Y3) & c(Y4) & bdouble(Y1, Y2) & bdouble(Y2, Y1) & bsingle(Y1, Y3) & bsingle(Y3, Y1) & bsingle(Y1, Y4) & bsingle(Y4, Y1) & (Y3) != (Y4)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'O' and Y3.GetSymbol() == 'C' and Y4.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y3.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y3.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y4.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y4.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (Y3 != Y4)) for Y4 in mol.GetAtoms() for Y3 in mol.GetAtoms() for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def unsaturated(mol: Chem.Mol, so_elements):
+    # (unsaturated()) <=> ((∃[Y1, Y2]: (c(Y1) & c(Y2) & bdouble(Y1, Y2) & bdouble(Y2, Y1)) | ∃[Y1, Y2]: (c(Y1) & c(Y2) & btriple(Y1, Y2) & btriple(Y2, Y1))))
+    return (any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.DOUBLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.DOUBLE)) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms()) or any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'C' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.TRIPLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.TRIPLE)) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms()))
+
+def saturated(mol: Chem.Mol, so_elements):
+    # (saturated()) <=> (∃[Y1]: (c(Y1) & ~(unsaturated())))
+    return any((Y1.GetSymbol() == 'C' and not(unsaturated(mol, so_elements, ))) for Y1 in mol.GetAtoms())
+
+def organophosphorus(mol: Chem.Mol, so_elements):
+    # (organophosphorus()) <=> (∃[Y1, Y2]: (c(Y1) & p(Y2) & bsingle(Y1, Y2) & bsingle(Y2, Y1)))
+    return any((Y1.GetSymbol() == 'C' and Y2.GetSymbol() == 'P' and (mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()).GetBondType() == Chem.BondType.SINGLE) and (mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()).GetBondType() == Chem.BondType.SINGLE)) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())
+
+def alkane(mol: Chem.Mol, so_elements):
+    # (alkane()) <=> ((saturated() & hydroCarbon() & ~(cyclic())))
+    return (saturated(mol, so_elements, ) and hydroCarbon(mol, so_elements, ) and not(cyclic(mol, so_elements, )))
+
+def haloAlkane(mol: Chem.Mol, so_elements):
+    # (haloAlkane()) <=> ((saturated() & haloHydroCarbon() & ~(cyclic())))
+    return (saturated(mol, so_elements, ) and haloHydroCarbon(mol, so_elements, ) and not(cyclic(mol, so_elements, )))
+
+def heteroOrganic(mol: Chem.Mol, so_elements):
+    # (heteroOrganic()) <=> (∃[Y1, Y2]: (c(Y1) & ~(c(Y2)) & ~(h(Y2)) & has_bond_to(Y1, Y2) & has_bond_to(Y2, Y1)))
+    return any((Y1.GetSymbol() == 'C' and not(Y2.GetSymbol() == 'C') and not(Y2.GetSymbol() == 'H') and mol.GetBondBetweenAtoms(Y1.GetIdx(), Y2.GetIdx()) is not None and mol.GetBondBetweenAtoms(Y2.GetIdx(), Y1.GetIdx()) is not None) for Y1 in mol.GetAtoms() for Y2 in mol.GetAtoms())

--- a/chemlog/lopster/lopster_rules_atom_level.pl
+++ b/chemlog/lopster/lopster_rules_atom_level.pl
@@ -34,6 +34,7 @@ noble(X) :- kr(X).
 noble(X) :- ne(X).
 noble(X) :- rn(X).
 noble(X) :- xe(X).
+noble(X) :- og(X).
 
 % cyclic molecules
 cleanReachable(X,Y,Z) :- bond(X,Y), bond(Y,X), bond(Y,Z), bond(Z,Y), X != Y, Y != Z, X != Z.
@@ -47,3 +48,4 @@ halogen(X) :- cl(X).
 halogen(X) :- br(X).
 halogen(X) :- i(X).
 halogen(X) :- at(X).
+halogen(X) :- ts(X). 

--- a/chemlog/lopster/lopster_rules_atom_level.pl
+++ b/chemlog/lopster/lopster_rules_atom_level.pl
@@ -1,0 +1,49 @@
+% rules taken from https://github.com/magkades/lopster/blob/1e4ae80367319b6c721e78b2ffd9d44b72eb22c2/src/main/resources/input/chemrules/chemRulesWithCyclic
+% Magka, Despoina, Markus Krötzsch, and Ian Horrocks. "A rule-based ontological framework for the classification of molecules." Journal of biomedical semantics 5.1 (2014): 17.
+
+bond(X,Y) :- single(X,Y).
+bond(X,Y) :- double(X,Y).
+bond(X,Y) :- triple(X,Y).
+
+horc(X) :- h(X).
+horc(X) :- c(X).
+
+charged(X) :- plus3(X).
+charged(X) :- plus2(X).
+charged(X) :- plus1(X).
+charged(X) :- minus3(X).
+charged(X) :- minus2(X).
+charged(X) :- minus1(X).
+
+midOxygen(Y) :- hasAtom(X,Y), o(Y), hasAtom(X,Y1), hasAtom(X,Y2), bond(Y,Y1), bond(Y1,Y), bond(Y,Y2), bond(Y2,Y), Y1!=Y2.
+
+bondAtLeast1(X) :- bond(X,Y1), bond(Y1,X).
+bondAtLeast2(X) :- bond(X,Y1), bond(Y1,X), bond(X,Y2), bond(Y2,X), Y1!=Y2.
+bondAtLeast3(X) :- bond(X,Y1), bond(Y1,X), bond(X,Y2), bond(Y2,X), bond(X,Y3), bond(Y3,X), Y1!=Y2, Y1!=Y3, Y2!=Y3.
+bondAtLeast4(X) :- bond(X,Y1), bond(Y1,X), bond(X,Y2), bond(Y2,X), bond(X,Y3), bond(Y3,X), bond(X,Y4), bond(Y4,X), Y1!=Y2, Y1!=Y3, Y1!=Y4, Y2!=Y3, Y2!=Y4, Y3!=Y4.
+bondExactly2(X) :- bondAtLeast2(X), not bondAtLeast3(X).
+bondExactly3(X) :- bondAtLeast3(X), not bondAtLeast4(X).
+bond1to3(X) :- bondAtLeast1(X), not bondAtLeast4(X).
+
+acylCarbon(Y) :- hasAtom(X,Y), c(Y), hasAtom(X,Z), o(Z), double(Y,Z), double(Z,Y).
+
+%noble gas atoms
+noble(X) :- ar(X).
+noble(X) :- he(X).
+noble(X) :- kr(X).
+noble(X) :- ne(X).
+noble(X) :- rn(X).
+noble(X) :- xe(X).
+
+% cyclic molecules
+cleanReachable(X,Y,Z) :- bond(X,Y), bond(Y,X), bond(Y,Z), bond(Z,Y), X != Y, Y != Z, X != Z.
+cleanReachable(X,Z,W) :- cleanReachable(X,Y,Z), bond(Z,W), bond(W,Z), X != W, Y != W, W != Z.
+closedLoopAtLeast3(X) :- cleanReachable(X,Y,Z), bond(Z,X), bond(X,Z).
+
+
+% halogens (this is not part of the original rule set)
+halogen(X) :- f(X).
+halogen(X) :- cl(X).
+halogen(X) :- br(X).
+halogen(X) :- i(X).
+halogen(X) :- at(X).

--- a/chemlog/lopster/lopster_rules_molecule_level.pl
+++ b/chemlog/lopster/lopster_rules_molecule_level.pl
@@ -15,12 +15,15 @@ fluorineMolEntity(X) :- molecule(X), hasAtom(X,Y), f(Y).
 % molecules that contain iodine
 iodineMolEntity(X) :- molecule(X), hasAtom(X,Y), i(Y).
 
+tsMolEntity(X) :- molecule(X), hasAtom(X,Y), ts(Y).
+
 % molecules that contain halogens
 halogenMolEntity(X) :- bromineMolEntity(X).
 halogenMolEntity(X) :- chlorineMolEntity(X).
 halogenMolEntity(X) :- fluorineMolEntity(X).
 halogenMolEntity(X) :- astatineMolEntity(X).
 halogenMolEntity(X) :- iodineMolEntity(X).
+halogenMolEntity(X) :- tsMolEntity(X).
 
 
 % molecules that contain polonium
@@ -35,12 +38,15 @@ sulfurMolEntity(X) :- molecule(X), hasAtom(X,Y), s(Y).
 % molecules that contain tellurium
 telluriumMolEntity(X) :- molecule(X), hasAtom(X,Y), te(Y).
 
+livermoriumMolEntity(X) :- molecule(X), hasAtom(X,Y), lv(Y).
+
 % molecules that are chalcogens
 chalcogenMolEntity(X) :- oxygenMolEntity(X).
 chalcogenMolEntity(X) :- poloniumMolEntity(X).
 chalcogenMolEntity(X) :- seleniumMolEntity(X).
 chalcogenMolEntity(X) :- sulfurMolEntity(X).
 chalcogenMolEntity(X) :- telluriumMolEntity(X).
+chalcogenMolEntity(X) :- livermoriumMolEntity(X).
 
 % molecules that contain antimony
 antimonyMolEntity(X) :- molecule(X), hasAtom(X,Y), sb(Y).
@@ -54,12 +60,15 @@ bismuthMolEntity(X) :- molecule(X), hasAtom(X,Y), bi(Y).
 % molecules that contain nitrogen
 nitrogenMolEntity(X) :- molecule(X), hasAtom(X,Y), n(Y).
 
+moscoviumMolEntity(X) :- molecule(X), hasAtom(X,Y), mc(Y).
+
 % molecules that are pnictogens
 pnictogenMolEntity(X) :- antimonyMolEntity(X).
 pnictogenMolEntity(X) :- arsenicMolEntity(X).
 pnictogenMolEntity(X) :- bismuthMolEntity(X).
 pnictogenMolEntity(X) :- nitrogenMolEntity(X).
 pnictogenMolEntity(X) :- phosphorusMolEntity(X).
+pnictogenMolEntity(X) :- moscoviumMolEntity(X).
 
 % molecules that contain chromium
 chromiumMolEntity(X) :- molecule(X), hasAtom(X,Y), cr(Y).
@@ -166,7 +175,7 @@ unsaturated(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), c(Y2), tripl
 saturated(X) :- molecule(X), hasAtom(X,Y1), c(Y1), not unsaturated(X).
 
 % organophosphorus molecules
-organophosphorus(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), p(Y2), single(Y1,Y2), single(Y2,Y1).
+organophosphorus(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), p(Y2), bond(Y1,Y2), bond(Y2,Y1).
 
 % alkane molecules
 alkane(X) :- saturated(X), hydroCarbon(X), not cyclic(X).

--- a/chemlog/lopster/lopster_rules_molecule_level.pl
+++ b/chemlog/lopster/lopster_rules_molecule_level.pl
@@ -1,0 +1,178 @@
+%% for these rules, X is a molecule (either explicit or implicit)
+
+% molecules that contain astatine
+astatineMolEntity(X) :- molecule(X), hasAtom(X,Y), at(Y).
+
+% molecules that contain bromine
+bromineMolEntity(X) :- molecule(X), hasAtom(X,Y), br(Y).
+
+% molecules that contain chlorine
+chlorineMolEntity(X) :- molecule(X), hasAtom(X,Y), cl(Y).
+
+% molecules that contain fluorine
+fluorineMolEntity(X) :- molecule(X), hasAtom(X,Y), f(Y).
+
+% molecules that contain iodine
+iodineMolEntity(X) :- molecule(X), hasAtom(X,Y), i(Y).
+
+% molecules that contain halogens
+halogenMolEntity(X) :- bromineMolEntity(X).
+halogenMolEntity(X) :- chlorineMolEntity(X).
+halogenMolEntity(X) :- fluorineMolEntity(X).
+halogenMolEntity(X) :- astatineMolEntity(X).
+halogenMolEntity(X) :- iodineMolEntity(X).
+
+
+% molecules that contain polonium
+poloniumMolEntity(X) :- molecule(X), hasAtom(X,Y), po(Y).
+
+% molecules that contain selenium
+seleniumMolEntity(X) :- molecule(X), hasAtom(X,Y), se(Y).
+
+% molecules that contain sulfur
+sulfurMolEntity(X) :- molecule(X), hasAtom(X,Y), s(Y).
+
+% molecules that contain tellurium
+telluriumMolEntity(X) :- molecule(X), hasAtom(X,Y), te(Y).
+
+% molecules that are chalcogens
+chalcogenMolEntity(X) :- oxygenMolEntity(X).
+chalcogenMolEntity(X) :- poloniumMolEntity(X).
+chalcogenMolEntity(X) :- seleniumMolEntity(X).
+chalcogenMolEntity(X) :- sulfurMolEntity(X).
+chalcogenMolEntity(X) :- telluriumMolEntity(X).
+
+% molecules that contain antimony
+antimonyMolEntity(X) :- molecule(X), hasAtom(X,Y), sb(Y).
+
+% molecules that contain arsenic
+arsenicMolEntity(X) :- molecule(X), hasAtom(X,Y), as(Y).
+
+% molecules that contain bismuth
+bismuthMolEntity(X) :- molecule(X), hasAtom(X,Y), bi(Y).
+
+% molecules that contain nitrogen
+nitrogenMolEntity(X) :- molecule(X), hasAtom(X,Y), ni(Y).
+
+% molecules that are pnictogens
+pnictogenMolEntity(X) :- antimonyMolEntity(X).
+pnictogenMolEntity(X) :- arsenicMolEntity(X).
+pnictogenMolEntity(X) :- bismuthMolEntity(X).
+pnictogenMolEntity(X) :- nitrogenMolEntity(X).
+pnictogenMolEntity(X) :- phosphorusMolEntity(X).
+
+% molecules that contain chromium
+chromiumMolEntity(X) :- molecule(X), hasAtom(X,Y), cr(Y).
+
+% molecules that contain molybdenum
+molybdenumMolEntity(X) :- molecule(X), hasAtom(X,Y), mo(Y).
+
+% molecules that contain seaborgium
+seaborgiumMolEntity(X) :- molecule(X), hasAtom(X,Y), sg(Y).
+
+% molecules that contain tungsten
+tungstenMolEntity(X) :- molecule(X), hasAtom(X,Y), w(Y).
+
+% molecules that belong to the chromium group
+chromiumGroupMolEntity(X) :- chromiumMolEntity(X).
+chromiumGroupMolEntity(X) :- molybdenumMolEntity(X).
+chromiumGroupMolEntity(X) :- seaborgiumMolEntity(X).
+chromiumGroupMolEntity(X) :- tungstenMolEntity(X).
+
+% molecules that contain noble gas atoms
+nobleGasMolEntity(X) :- molecule(X), hasAtom(X,Y), noble(Y).
+
+% molecules that contain carbon
+carbonMolEntity(X) :- molecule(X), hasAtom(X,Y), c(Y).
+
+% molecules that contain oxygen
+oxygenMolEntity(X) :- molecule(X), hasAtom(X,Y), o(Y).
+
+% molecules that contain hydrogen
+hydrogenMolEntity(X) :- molecule(X), hasAtom(X,Y), h(Y).
+
+% molecules that contain phosphorus
+phosphorusMolEntity(X) :- molecule(X), hasAtom(X,Y), p(Y).
+
+% molecules that do not contain carbon
+inorganic(X) :- molecule(X), not carbonMolEntity(X).
+
+% molecules that contain carbon, hydrogen and consist only of carbon and hydrogen
+notHydroCarbon(X) :- hasAtom(X,Y), not c(Y), not h(Y).
+hydroCarbon(X) :- carbonMolEntity(X), not notHydroCarbon(X).
+
+% molecules that contain carbon, hydrogen and halogen and consist only of carbon, hydrogen and halogen
+notHaloHydroCarbon(X) :- hasAtom(X,Y), not c(Y), not h(Y), not halogen(Y).
+haloHydroCarbon(X) :- carbonMolEntity(X), halogenMolEntity(X), not notHaloHydroCarbon(X).
+
+% molecules that contain exactly one carbon
+atLeast2Carbons(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), c(Y2), Y1 != Y2.
+exactly1Carbon(X) :- carbonMolEntity(X), not atLeast2Carbons(X).
+
+% molecules that contain exactly two carbons
+atLeast3Carbons(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), c(Y2), Y1 != Y2, hasAtom(X,Y3), c(Y3), Y1 != Y3, Y2 != Y3.
+exactly2Carbons(X) :- atLeast2Carbons(X), not atLeast3Carbons(X).
+
+% molecules that contain exactly three carbons
+atLeast4Carbons(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), c(Y2), Y1 != Y2, hasAtom(X,Y3), c(Y3), Y1 != Y3, Y2 != Y3, hasAtom(X,Y4), c(Y4), Y1 != Y4, Y2 != Y4, Y3 != Y4.
+exactly3Carbons(X) :- atLeast3Carbons(X), not atLeast4Carbons(X).
+
+% molecules that contain exactly four carbons
+atLeast5Carbons(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), c(Y2), Y1 != Y2, hasAtom(X,Y3), c(Y3), Y1 != Y3, Y2 != Y3, hasAtom(X,Y4), c(Y4), Y1 != Y4, Y2 != Y4, Y3 != Y4, hasAtom(X,Y5), c(Y5), Y1 != Y5, Y2 != Y5, Y3 != Y5, Y4 != Y5.
+exactly4Carbons(X) :- atLeast4Carbons(X), not atLeast5Carbons(X).
+
+% molecules that contain at least two atoms
+polyatomic(X) :- molecule(X), hasAtom(X,Y1), hasAtom(X,Y2), Y1 != Y2.
+
+% molecules that contains exactly one atom
+monoatomic(X) :- molecule(X), hasAtom(X,Y1),not polyatomic(X).
+
+% molecules that contain a carboxy group
+carboxylicAcid(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3).
+
+% molecules that contain exactly one carboxy group
+atLeast2CarboxyGroups(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3), hasAtom(X,Y5), c(Y5), hasAtom(X,Y6), o(Y6), hasAtom(X,Y7), o(Y7), hasAtom(X,Y8), horc(Y8), double(Y5,Y6), double(Y6,Y5), single(Y5,Y7), single(Y7,Y5), single(Y5,Y8), single(Y8,Y5), not midOxygen(Y7), not charged(Y7), Y1!=Y5.
+exactly1CarboxyGroup(X) :- carboxylicAcid(X), not atLeast2CarboxyGroups(X).
+
+% molecules that contain exactly two carboxy groups
+atLeast3CarboxyGroups(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3), hasAtom(X,Y5), c(Y5), hasAtom(X,Y6), o(Y6), hasAtom(X,Y7), o(Y7), hasAtom(X,Y8), horc(Y8), double(Y5,Y6), double(Y6,Y5), single(Y5,Y7), single(Y7,Y5), single(Y5,Y8), single(Y8,Y5), not midOxygen(Y7), not charged(Y7), hasAtom(X,Y9), c(Y9), hasAtom(X,Y10), o(Y10), hasAtom(X,Y11), o(Y11), hasAtom(X,Y12), horc(Y12), double(Y9,Y10), double(Y10,Y9), single(Y9,Y11), single(Y11,Y9), single(Y9,Y12), single(Y12,Y9), not midOxygen(Y11), not charged(Y11), Y1!=Y5, Y9!=Y5, Y9!=Y1.
+exactly2CarboxyGroups(X) :- atLeast2CarboxyGroups(X), not atLeast3CarboxyGroups(X).
+
+% molecules that are carboxylic esters
+carboxylicEster(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), c(Y4), hasAtom(X,Y5), horc(Y5), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y5), single(Y5,Y1), single(Y3,Y4), single(Y4,Y3).
+
+% molecules that contain a benzene ring
+hasBenzeneRing(X) :- molecule(X), hasAtom(X,Y1), c(Y1),  hasAtom(X,Y2), c(Y2), single(Y1,Y2), single(Y2,Y1), hasAtom(X,Y3), c(Y3), double(Y2,Y3), double(Y3,Y2), hasAtom(X,Y4), c(Y4), single(Y3,Y4), single(Y4,Y3), hasAtom(X,Y5), double(Y4,Y5), double(Y5,Y4), c(Y5), hasAtom(X,Y6), c(Y6), single(Y5,Y6), single(Y6,Y5), double(Y6,Y1), double(Y1,Y6).
+
+% molecules that contain a four-membered ring
+hasFourMemberedRing(X) :- molecule(X), hasAtom(X,Y1), hasAtom(X,Y2), Y1 != Y2, bond(Y1,Y2), bond(Y2,Y1), hasAtom(X,Y3), Y1 != Y3,  Y2 != Y3, bond(Y2,Y3), bond(Y3,Y2), hasAtom(X,Y4), Y1 != Y4, Y2 != Y4, Y3 != Y4, bond(Y3,Y4), bond(Y4,Y3), bond(Y4,Y1), bond(Y1,Y4).
+
+% molecules that are amines
+amine(X) :- molecule(X), hasAtom(X,Y1), n(Y1), bond1to3(Y1), hasAtom(X,Y2), horc(Y2), hasAtom(X,Y3), horc(Y3), hasAtom(X,Y4), c(Y4), single(Y1,Y2), single(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not acylCarbon(Y2), not acylCarbon(Y3), not acylCarbon(Y4), Y2!=Y3, Y2!=Y4, Y3!=Y4.
+
+% molecules that are aldehydes
+aldehyde(X) :- molecule(X), hasAtom(X,Y1), c(Y1), bondExactly2(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), horc(Y3), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1).
+
+cyclic(X) :- hasAtom(X,Y), molecule(X), closedLoopAtLeast3(Y).
+
+% molecules that are ketone
+ketone(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), c(Y3), hasAtom(X,Y4), c(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), Y3!=Y4.
+
+% organic molecules that are unsaturated
+unsaturated(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), c(Y2), double(Y1,Y2), double(Y2,Y1).
+unsaturated(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), c(Y2), triple(Y1,Y2), triple(Y2,Y1).
+
+% organic molecules that are saturated
+saturated(X) :- molecule(X), hasAtom(X,Y1), c(Y1), not unsaturated(X).
+
+% organophosphorus molecules
+organophosphorus(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), p(Y2), single(Y1,Y2), single(Y2,Y1).
+
+% alkane molecules
+alkane(X) :- saturated(X), hydroCarbon(X), not cyclic(X).
+
+% haloalkane molecules
+haloAlkane(X) :- saturated(X), haloHydroCarbon(X), not cyclic(X).
+
+% molecules that contain at least one (possibly acyl) carbon connected with a non-carbon atom
+heteroOrganic(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), not c(Y2),  not h(Y2), bond(Y1,Y2), bond(Y2,Y1).

--- a/chemlog/lopster/lopster_rules_molecule_level.pl
+++ b/chemlog/lopster/lopster_rules_molecule_level.pl
@@ -52,7 +52,7 @@ arsenicMolEntity(X) :- molecule(X), hasAtom(X,Y), as(Y).
 bismuthMolEntity(X) :- molecule(X), hasAtom(X,Y), bi(Y).
 
 % molecules that contain nitrogen
-nitrogenMolEntity(X) :- molecule(X), hasAtom(X,Y), ni(Y).
+nitrogenMolEntity(X) :- molecule(X), hasAtom(X,Y), n(Y).
 
 % molecules that are pnictogens
 pnictogenMolEntity(X) :- antimonyMolEntity(X).
@@ -130,13 +130,13 @@ monoatomic(X) :- molecule(X), hasAtom(X,Y1),not polyatomic(X).
 % molecules that contain a carboxy group
 carboxylicAcid(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3).
 
-% molecules that contain exactly one carboxy group
-atLeast2CarboxyGroups(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3), hasAtom(X,Y5), c(Y5), hasAtom(X,Y6), o(Y6), hasAtom(X,Y7), o(Y7), hasAtom(X,Y8), horc(Y8), double(Y5,Y6), double(Y6,Y5), single(Y5,Y7), single(Y7,Y5), single(Y5,Y8), single(Y8,Y5), not midOxygen(Y7), not charged(Y7), Y1!=Y5.
-exactly1CarboxyGroup(X) :- carboxylicAcid(X), not atLeast2CarboxyGroups(X).
+% molecules that contain exactly one carboxy group (not needed for ChEBI classification)
+%atLeast2CarboxyGroups(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3), hasAtom(X,Y5), c(Y5), hasAtom(X,Y6), o(Y6), hasAtom(X,Y7), o(Y7), hasAtom(X,Y8), horc(Y8), double(Y5,Y6), double(Y6,Y5), single(Y5,Y7), single(Y7,Y5), single(Y5,Y8), single(Y8,Y5), not midOxygen(Y7), not charged(Y7), Y1!=Y5.
+%exactly1CarboxyGroup(X) :- carboxylicAcid(X), not atLeast2CarboxyGroups(X).
 
 % molecules that contain exactly two carboxy groups
-atLeast3CarboxyGroups(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3), hasAtom(X,Y5), c(Y5), hasAtom(X,Y6), o(Y6), hasAtom(X,Y7), o(Y7), hasAtom(X,Y8), horc(Y8), double(Y5,Y6), double(Y6,Y5), single(Y5,Y7), single(Y7,Y5), single(Y5,Y8), single(Y8,Y5), not midOxygen(Y7), not charged(Y7), hasAtom(X,Y9), c(Y9), hasAtom(X,Y10), o(Y10), hasAtom(X,Y11), o(Y11), hasAtom(X,Y12), horc(Y12), double(Y9,Y10), double(Y10,Y9), single(Y9,Y11), single(Y11,Y9), single(Y9,Y12), single(Y12,Y9), not midOxygen(Y11), not charged(Y11), Y1!=Y5, Y9!=Y5, Y9!=Y1.
-exactly2CarboxyGroups(X) :- atLeast2CarboxyGroups(X), not atLeast3CarboxyGroups(X).
+%atLeast3CarboxyGroups(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), horc(Y4), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y4), single(Y4,Y1), not midOxygen(Y3), not charged(Y3), hasAtom(X,Y5), c(Y5), hasAtom(X,Y6), o(Y6), hasAtom(X,Y7), o(Y7), hasAtom(X,Y8), horc(Y8), double(Y5,Y6), double(Y6,Y5), single(Y5,Y7), single(Y7,Y5), single(Y5,Y8), single(Y8,Y5), not midOxygen(Y7), not charged(Y7), hasAtom(X,Y9), c(Y9), hasAtom(X,Y10), o(Y10), hasAtom(X,Y11), o(Y11), hasAtom(X,Y12), horc(Y12), double(Y9,Y10), double(Y10,Y9), single(Y9,Y11), single(Y11,Y9), single(Y9,Y12), single(Y12,Y9), not midOxygen(Y11), not charged(Y11), Y1!=Y5, Y9!=Y5, Y9!=Y1.
+%exactly2CarboxyGroups(X) :- atLeast2CarboxyGroups(X), not atLeast3CarboxyGroups(X).
 
 % molecules that are carboxylic esters
 carboxylicEster(X) :- molecule(X), hasAtom(X,Y1), c(Y1), hasAtom(X,Y2), o(Y2), hasAtom(X,Y3), o(Y3), hasAtom(X,Y4), c(Y4), hasAtom(X,Y5), horc(Y5), double(Y1,Y2), double(Y2,Y1), single(Y1,Y3), single(Y3,Y1), single(Y1,Y5), single(Y5,Y1), single(Y3,Y4), single(Y4,Y3).

--- a/chemlog/lopster/translate_lopster.py
+++ b/chemlog/lopster/translate_lopster.py
@@ -156,7 +156,7 @@ def run_lopster_translation():
     import os 
     lopster_file = os.path.join(os.path.dirname(__file__), 'lopster_rules_atom_level.pl')
     lopster_file_molecules = os.path.join(os.path.dirname(__file__), 'lopster_rules_molecule_level.pl')
-    with open(os.path.join(os.path.dirname(__file__), 'lopster_python.py'), 'w+', encoding='utf-8') as f:
+    with open(os.path.join(os.path.dirname(__file__), 'lopster_python_new.py'), 'w+', encoding='utf-8') as f:
         f.write("from rdkit import Chem\n")
         f.write("# Generated Python code from Lopster rules\n\n")
         f.write(lopster_to_python(lopster_file, remove_x=False))

--- a/chemlog/lopster/translate_lopster.py
+++ b/chemlog/lopster/translate_lopster.py
@@ -1,0 +1,164 @@
+from gavel.logic.problem import AnnotatedFormula
+from gavel.dialects.prolog.parser import PrologParser
+from gavel.logic import logic
+
+from chemlog.fol_to_py.folToPyTranslator import SO_KEY, PythonCompiler
+
+def lopster_to_fol(lopster_path: str, remove_x=False) -> list[AnnotatedFormula]:
+    """
+    Translates a Lopster program into a list of AnnotatedFormulas in FOL.
+
+    Args:
+        lopster_path (str): Path to the Lopster program file.
+
+    Returns:
+        list[AnnotatedFormula]: List of AnnotatedFormulas representing the Lopster program in FOL.
+
+    """
+
+    parser = PrologParser()
+    with open(lopster_path, 'r') as file:
+        lopster_program = file.read()
+
+    predicate_name_mapping = {
+        "single": "bsingle",
+        "double": "bdouble",
+        "triple": "btriple",
+        "minus3": "charge_m3",
+        "minus2": "charge_m2",
+        "minus1": "charge_m1",
+        "plus1": "charge1",
+        "plus2": "charge2",
+        "plus3": "charge3",
+        "bond": "has_bond_to",
+    }
+    for lopster_name, fol_name in predicate_name_mapping.items():
+        lopster_program = lopster_program.replace(lopster_name, fol_name)
+    annotated_formulas = parser.parse(lopster_program)
+
+    # remove molecule/1 and hasAtom/2 predicates from bodies
+    # optional: remove X variable
+    for af in annotated_formulas:
+        body = af.formula.formula.left
+        new_formulae = []
+        if isinstance(body, logic.NaryFormula):
+            for atom in body.formulae:
+                if isinstance(atom, logic.PredicateExpression):
+                    if atom.predicate == "molecule" or atom.predicate == "hasAtom":
+                        continue
+                    if remove_x:
+                        atom.arguments = [s for s in atom.arguments if s != logic.Variable("X")]
+                if isinstance(atom, logic.UnaryFormula) and isinstance(atom.formula, logic.PredicateExpression):
+                    if atom.formula.predicate == "molecule" or atom.formula.predicate == "hasAtom":
+                        continue
+                    if remove_x:
+                        atom.formula.arguments = [s for s in atom.formula.arguments if s != logic.Variable("X")]
+                new_formulae.append(atom)
+            af.formula.formula.left = logic.NaryFormula(
+                operator=logic.BinaryConnective.CONJUNCTION,
+                formulae=new_formulae
+            )
+        elif isinstance(body, logic.PredicateExpression):
+            if body.predicate == "molecule" or body.predicate == "hasAtom":
+                af.formula.formula.left = logic.NaryFormula(
+                    operator=logic.BinaryConnective.CONJUNCTION,
+                    formulae=[]
+                )
+            if remove_x:
+                body.arguments = [s for s in body.arguments if s != logic.Variable("X")]
+        elif isinstance(body, logic.UnaryFormula) and isinstance(body.formula, logic.PredicateExpression):
+            if body.formula.predicate == "molecule" or body.formula.predicate == "hasAtom":
+                af.formula.formula.left = logic.NaryFormula(
+                    operator=logic.BinaryConnective.CONJUNCTION,
+                    formulae=[]
+                )
+            if remove_x:
+                body.formula.arguments = [s for s in body.formula.arguments if s != logic.Variable("X")]
+        if remove_x:
+            head = af.formula.formula.right
+            if isinstance(head, logic.PredicateExpression):
+                head.arguments = [s for s in head.arguments if s != logic.Variable("X")]
+            af.formula.formula.right = head
+            af.formula.variables = [v for v in af.formula.variables if v.symbol != "X"]
+
+    return annotated_formulas
+
+def lopster_to_python(lopster_path: str, verbose: bool = False, remove_x: bool = False) -> str:
+    """
+    Translates a Lopster program into Python code.
+
+    Args:
+        lopster_path (str): Path to the Lopster program file.
+
+    Returns:
+        str: Python code representing the Lopster program.
+
+    """
+
+    fol_formulas = lopster_to_fol(lopster_path, remove_x=remove_x)
+    # todo: turn implication rules into definitions
+    # collect implications and convert to definitions
+    # A -> C, B -> C becomes (A or B) <-> C
+    bodies = dict()
+    for formula in fol_formulas:
+        assert isinstance(formula.formula, logic.QuantifiedFormula) and formula.formula.quantifier == logic.Quantifier.UNIVERSAL
+        impl = formula.formula.formula
+        assert isinstance(impl, logic.BinaryFormula) and impl.operator == logic.BinaryConnective.IMPLICATION
+        head = impl.right
+        body = impl.left
+        head_key = str(head)
+        # add body-specific quantifiers
+        vars = set(formula.formula.variables)
+        head_vars = set(head.arguments) if isinstance(head, logic.PredicateExpression) else set()
+        # moving quantifier into the body turns universal quantifiers into existential ones
+        vars -= head_vars
+        if vars:
+            body = logic.QuantifiedFormula(logic.Quantifier.EXISTENTIAL, list(vars), body)
+        if head_key not in bodies:
+            bodies[head_key] = []
+        bodies[head_key].append((head, body))
+    if verbose:
+        for head_key, body_list in bodies.items():
+            print(f"Head: {head_key}")
+            for head, body in body_list:
+                print(f"  Body: {body}")
+    definitions = dict()
+    for head_key, body_list in bodies.items():
+        if len(body_list) > 1:
+            combined_body = logic.NaryFormula(
+                operator=logic.BinaryConnective.DISJUNCTION,
+                formulae=[body for head, body in body_list]
+            )
+        else:
+            combined_body = body_list[0][1]
+        head = body_list[0][0]
+        assert isinstance(head, logic.PredicateExpression)
+        definition = logic.BinaryFormula(
+            left=head,
+            operator=logic.BinaryConnective.BIIMPLICATION,
+            right=combined_body
+        )
+        definitions[head.predicate] = definition
+    # todo: translate definitions to Python code using PythonCompiler
+    compiler = PythonCompiler(mol=None)
+    python_codes = []
+    for name, definition in definitions.items():
+        definition = f"def {name}({', '.join(['mol: Chem.Mol', SO_KEY] + [str(a) for a in definition.left.arguments])}):\n" \
+                    f"    # {definition}\n" \
+                    f"    return {compiler.visit(definition.right)}\n"
+        python_codes.append(definition)
+    return "\n".join(python_codes)
+
+def run_lopster_translation():
+    """
+    Runs the Lopster to Python translation and writes the output to a file.
+    """
+    import os 
+    lopster_file = os.path.join(os.path.dirname(__file__), 'lopster_rules_atom_level.pl')
+    lopster_file_molecules = os.path.join(os.path.dirname(__file__), 'lopster_rules_molecule_level.pl')
+    with open(os.path.join(os.path.dirname(__file__), 'lopster_python.py'), 'w+', encoding='utf-8') as f:
+        f.write("from rdkit import Chem\n")
+        f.write("# Generated Python code from Lopster rules\n\n")
+        f.write(lopster_to_python(lopster_file, remove_x=False))
+        f.write("\n\n")
+        f.write(lopster_to_python(lopster_file_molecules, remove_x=True))

--- a/chemlog/lopster/translate_lopster.py
+++ b/chemlog/lopster/translate_lopster.py
@@ -1,5 +1,5 @@
 from gavel.logic.problem import AnnotatedFormula
-from gavel.dialects.prolog.parser import PrologParser
+from gavel.dialects.logic_programs.parser import LogicProgramParser
 from gavel.logic import logic
 
 from chemlog.fol_to_py.folToPyTranslator import SO_KEY, PythonCompiler
@@ -16,7 +16,7 @@ def lopster_to_fol(lopster_path: str, remove_x=False) -> list[AnnotatedFormula]:
 
     """
 
-    parser = PrologParser()
+    parser = LogicProgramParser()
     with open(lopster_path, 'r') as file:
         lopster_program = file.read()
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'click',
         'tqdm',
         'multiprocess',
+        'clingo'
     ],
     author='sfluegel05',
     author_email='simon.fluegel@uos.de',


### PR DESCRIPTION
This adds rules from [Lopster](https://github.com/magkades/lopster/tree/master) to ChemLog.

This covers
- [x] the original rules (fixing a bug where `halogen` was undefined)
- [x] a translator that uses the gavel prolog parser to translate the Lopster rules to gavel's FOL syntax and then to Python
- [x] the resulting Python code
- [x] a classifier that maps the Lopster predicate names to 41 ChEBI classes (note that the original paper mentions 51 classes, but not all of them have a corresponding ChEBI class)