### PR TITLE
add model checking tests for peptides

### DIFF
--- a/tests/test_find_model.py
+++ b/tests/test_find_model.py
@@ -1,0 +1,548 @@
+"""Basic unit tests for ``ModelChecker.find_model``.
+
+These tests construct ``ModelChecker`` directly from small numpy extensions and
+gavel formulas (rather than going through the RDKit/parser pipeline), so they
+exercise ``find_model`` in isolation and document the expected outcome for a
+handful of simple extension/formula combinations.
+
+``find_model`` expects a normalised formula in prenex CNF with only existential
+quantifiers: the matrix is a conjunction (``NaryFormula`` with ``CONJUNCTION``)
+of clauses, and every clause is a disjunction (``NaryFormula`` with
+``DISJUNCTION``) of literals.
+"""
+
+import numpy as np
+import pytest
+from gavel.logic import logic
+
+from chemlog.fol_classification.model_checking import (
+    ModelChecker,
+    ModelCheckerOutcome,
+)
+
+
+@pytest.fixture
+def simple_checker():
+    """Universe of 3 with one unary and one binary predicate.
+
+    p = {0, 1}; edge = {(0, 1), (1, 2)}.
+    """
+    universe = 3
+    extensions = {
+        logic.BinaryConnective.EQ.name: np.array(
+            [[i == j for i in range(universe)] for j in range(universe)]
+        ),
+        "p": np.array([True, True, False]),
+        "edge": np.array(
+            [
+                [False, True, False],
+                [False, False, True],
+                [False, False, False],
+            ]
+        ),
+    }
+    return ModelChecker(universe, extensions)
+
+
+# --- ground (variable-free) formulas ----------------------------------------------
+
+
+def test_ground_literal_true(simple_checker):
+    formula = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("p", [0])],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+
+def test_ground_literal_false(simple_checker):
+    formula = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("p", [2])],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+def test_ground_negated_literal(simple_checker):
+    # ~p(2) holds because 2 is not in the extension of p.
+    holds = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [
+                    logic.UnaryFormula(
+                        logic.UnaryConnective.NEGATION,
+                        logic.PredicateExpression("p", [2]),
+                    )
+                ],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(holds)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+    # ~p(0) fails because 0 is in the extension of p.
+    fails = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [
+                    logic.UnaryFormula(
+                        logic.UnaryConnective.NEGATION,
+                        logic.PredicateExpression("p", [0]),
+                    )
+                ],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(fails)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+def test_ground_disjunction(simple_checker):
+    # One true disjunct is enough to satisfy the clause: p(2) is false but p(0) is true.
+    satisfiable = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [
+                    logic.PredicateExpression("p", [2]),
+                    logic.PredicateExpression("p", [0]),
+                ],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(satisfiable)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+    # Both disjuncts false -> no model.
+    unsatisfiable = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [
+                    logic.PredicateExpression("p", [2]),
+                    logic.PredicateExpression("edge", [2, 2]),
+                ],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(unsatisfiable)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+def test_ground_binary_predicate(simple_checker):
+    present = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("edge", [0, 1])],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(present)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+    # edge is directed; (1, 0) is not in the extension.
+    absent = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("edge", [1, 0])],
+            )
+        ],
+    )
+    outcome, _ = simple_checker.find_model(absent)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+def test_ground_conjunction_of_clauses(simple_checker):
+    # p(0) & edge(0, 1) both hold.
+    satisfiable = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("p", [0])],
+            ),
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("edge", [0, 1])],
+            ),
+        ],
+    )
+    outcome, _ = simple_checker.find_model(satisfiable)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+    # p(0) holds but edge(0, 2) does not -> the conjunction fails.
+    unsatisfiable = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("p", [0])],
+            ),
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("edge", [0, 2])],
+            ),
+        ],
+    )
+    outcome, _ = simple_checker.find_model(unsatisfiable)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+# --- existentially quantified formulas --------------------------------------------
+
+
+def test_existential_single_variable(simple_checker):
+    x = logic.Variable("X")
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("p", [x])],
+                )
+            ],
+        ),
+    )
+    outcome, _ = simple_checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+
+def test_existential_no_witness():
+    universe = 3
+    extensions = {
+        logic.BinaryConnective.EQ.name: np.array(
+            [[i == j for i in range(universe)] for j in range(universe)]
+        ),
+        "p": np.array([False, False, False]),
+    }
+    checker = ModelChecker(universe, extensions)
+    x = logic.Variable("X")
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("p", [x])],
+                )
+            ],
+        ),
+    )
+    outcome, _ = checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+def test_existential_two_variables(simple_checker):
+    x, y = logic.Variable("X"), logic.Variable("Y")
+    # There exist X, Y with edge(X, Y).
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x, y],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("edge", [x, y])],
+                )
+            ],
+        ),
+    )
+    outcome, _ = simple_checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+
+def test_existential_returns_allocations(simple_checker):
+    x, y = logic.Variable("X"), logic.Variable("Y")
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x, y],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("edge", [x, y])],
+                )
+            ],
+        ),
+    )
+    outcome, allocations = simple_checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+    assignment = dict(allocations)
+    # The only edges are (0, 1) and (1, 2); whichever is picked must be a real edge.
+    assert (assignment["X"], assignment["Y"]) in {(0, 1), (1, 2)}
+
+
+def test_existential_with_inequality(simple_checker):
+    x, y = logic.Variable("X"), logic.Variable("Y")
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x, y],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("edge", [x, y])],
+                ),
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.BinaryFormula(x, logic.BinaryConnective.NEQ, y)],
+                ),
+            ],
+        ),
+    )
+    outcome, _ = simple_checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+
+def test_existential_with_negated_literal(simple_checker):
+    x = logic.Variable("X")
+    # exists X: p(X) & ~edge(X, 0). p = {0, 1}; neither has an edge into 0, so any holds.
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("p", [x])],
+                ),
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [
+                        logic.UnaryFormula(
+                            logic.UnaryConnective.NEGATION,
+                            logic.PredicateExpression("edge", [x, 0]),
+                        )
+                    ],
+                ),
+            ],
+        ),
+    )
+    outcome, _ = simple_checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+
+def test_existential_shared_variable_unsatisfiable():
+    # p and q have no common witness, so "exists X: p(X) & q(X)" has no model.
+    universe = 3
+    extensions = {
+        logic.BinaryConnective.EQ.name: np.array(
+            [[i == j for i in range(universe)] for j in range(universe)]
+        ),
+        "p": np.array([True, False, False]),
+        "q": np.array([False, True, False]),
+    }
+    checker = ModelChecker(universe, extensions)
+    x = logic.Variable("X")
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("p", [x])],
+                ),
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("q", [x])],
+                ),
+            ],
+        ),
+    )
+    outcome, _ = checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+# --- all_different ----------------------------------------------------------------
+
+
+def test_all_different_blocks_reused_individual():
+    # Only individual 0 satisfies p, so two *distinct* witnesses cannot both satisfy it.
+    universe = 2
+    extensions = {
+        logic.BinaryConnective.EQ.name: np.array(
+            [[i == j for i in range(universe)] for j in range(universe)]
+        ),
+        "p": np.array([True, False]),
+    }
+    x, y = logic.Variable("X"), logic.Variable("Y")
+    formula = logic.QuantifiedFormula(
+        logic.Quantifier.EXISTENTIAL,
+        [x, y],
+        logic.NaryFormula(
+            logic.BinaryConnective.CONJUNCTION,
+            [
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("p", [x])],
+                ),
+                logic.NaryFormula(
+                    logic.BinaryConnective.DISJUNCTION,
+                    [logic.PredicateExpression("p", [y])],
+                ),
+            ],
+        ),
+    )
+
+    # Without all_different the same individual can fill both variables.
+    outcome, _ = ModelChecker(universe, extensions).find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+    # With all_different each variable needs its own individual -> no model.
+    outcome, _ = ModelChecker(universe, extensions, all_different=True).find_model(formula)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+# --- predicate definitions --------------------------------------------------------
+
+
+def test_definition_satisfied():
+    # Definition hasP <=> ?[X]: p(X) (a 0-ary derived predicate).
+    universe = 3
+    extensions = {
+        logic.BinaryConnective.EQ.name: np.array(
+            [[i == j for i in range(universe)] for j in range(universe)]
+        ),
+        "p": np.array([False, True, False]),
+    }
+    x = logic.Variable("X")
+    definitions = {
+        "hasP": (
+            [],
+            logic.QuantifiedFormula(
+                logic.Quantifier.EXISTENTIAL,
+                [x],
+                logic.NaryFormula(
+                    logic.BinaryConnective.CONJUNCTION,
+                    [
+                        logic.NaryFormula(
+                            logic.BinaryConnective.DISJUNCTION,
+                            [logic.PredicateExpression("p", [x])],
+                        )
+                    ],
+                ),
+            ),
+        )
+    }
+    checker = ModelChecker(universe, extensions, definitions)
+    formula = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("hasP", [])],
+            )
+        ],
+    )
+    outcome, _ = checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.MODEL_FOUND
+
+
+def test_definition_unsatisfied():
+    universe = 3
+    extensions = {
+        logic.BinaryConnective.EQ.name: np.array(
+            [[i == j for i in range(universe)] for j in range(universe)]
+        ),
+        "p": np.array([False, False, False]),
+    }
+    x = logic.Variable("X")
+    definitions = {
+        "hasP": (
+            [],
+            logic.QuantifiedFormula(
+                logic.Quantifier.EXISTENTIAL,
+                [x],
+                logic.NaryFormula(
+                    logic.BinaryConnective.CONJUNCTION,
+                    [
+                        logic.NaryFormula(
+                            logic.BinaryConnective.DISJUNCTION,
+                            [logic.PredicateExpression("p", [x])],
+                        )
+                    ],
+                ),
+            ),
+        )
+    }
+    checker = ModelChecker(universe, extensions, definitions)
+    formula = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("hasP", [])],
+            )
+        ],
+    )
+    outcome, _ = checker.find_model(formula)
+    assert outcome == ModelCheckerOutcome.NO_MODEL
+
+
+# --- inferred outcomes (proven/disproven cache) -----------------------------------
+
+
+def test_repeated_formula_is_inferred(simple_checker):
+    formula = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("p", [0])],
+            )
+        ],
+    )
+    first, _ = simple_checker.find_model(formula)
+    second, _ = simple_checker.find_model(formula)
+    assert first == ModelCheckerOutcome.MODEL_FOUND
+    # The second call short-circuits via the proven-formulae cache.
+    assert second == ModelCheckerOutcome.MODEL_FOUND_INFERRED
+
+
+def test_repeated_unsatisfiable_formula_is_inferred(simple_checker):
+    formula = logic.NaryFormula(
+        logic.BinaryConnective.CONJUNCTION,
+        [
+            logic.NaryFormula(
+                logic.BinaryConnective.DISJUNCTION,
+                [logic.PredicateExpression("p", [2])],
+            )
+        ],
+    )
+    first, _ = simple_checker.find_model(formula)
+    second, _ = simple_checker.find_model(formula)
+    assert first == ModelCheckerOutcome.NO_MODEL
+    assert second == ModelCheckerOutcome.NO_MODEL_INFERRED

--- a/tests/test_model_checking.py
+++ b/tests/test_model_checking.py
@@ -251,6 +251,121 @@ def test_model_checking_additional_examples(checker: "ModelCheckerTestWrapper"):
     checker.check_formula_for_molecule(formula_str, mol)
 
 
+# ---------------------------------------------------------------------------
+# Tests for the atom-level formulas in data/fol_specifications.
+#
+# ModelCheckerTestWrapper builds its extensions with mol_to_fol_atoms, i.e. the
+# domain consists of the atoms of a molecule. The functional-group specs below
+# are therefore checked directly; the fragment-level (charges.tptp,
+# fragment_*.tptp) and building-block-level (peptide_structure*.tptp) specs use
+# a different domain and are out of scope here.
+#
+# The definition strings are taken verbatim from the corresponding spec files.
+# SMILES are intentionally left as empty placeholders - fill them in with
+# molecules matching the description in each test; tests skip while empty.
+# ---------------------------------------------------------------------------
+
+# data/fol_specifications/functional_group_helpers.tptp
+AMIDE_BOND_DEF = (
+    "amide_bond(Ac, Ao, An) <=> (c(Ac) & o(Ao) & n(An) & (bSINGLE(Ac, Ao) | "
+    "bDOUBLE(Ac, Ao)) & (bSINGLE(Ac, Ao) | bSINGLE(Ac, An)) & (bDOUBLE(Ac, An) "
+    "| bDOUBLE(Ac, Ao)) & (bDOUBLE(Ac, An) | bSINGLE(Ac, An)) & (has_1_hs(Ao) | "
+    "charge_m1(Ao) | bDOUBLE(Ac, Ao)) & (has_1_hs(Ao) | charge_m1(Ao) | "
+    "bSINGLE(Ac, An)) )"
+)
+HAS_AMINO_NONCONFORMING_NEIGHBOR_DEF = (
+    "has_amino_nonconforming_neighbor(An) <=> ?[Neighbor, Ao]: "
+    "(has_bond_to(An, Neighbor) & (~c(Neighbor) | ~bSINGLE(An, Neighbor)) & "
+    "(~c(Neighbor) | ~bDOUBLE(An, Neighbor) | ~amide_bond(Neighbor, Ao, An)) & "
+    "(~h(Neighbor) | ~bSINGLE(An, Neighbor)) & (~h(Neighbor) | "
+    "~bDOUBLE(An, Neighbor) | ~amide_bond(Neighbor, Ao, An)) )"
+)
+
+# data/fol_specifications/functional_groups.tptp
+AMINO_RESIDUE_DEF = (
+    "amino_residue(An) <=> (n(An) & ~has_amino_nonconforming_neighbor(An))"
+)
+CARBOXY_RESIDUE_DEF = (
+    "carboxy_residue(Ac, Ad, As) <=> (c(Ac) & o(Ad) & ~c(As) & ~h(As) & "
+    "bDOUBLE(Ac, Ad) & bSINGLE(Ac, As) )"
+)
+
+# Placeholder SMILES - insert real molecules here.
+AMIDE_POSITIVE_SMILES = "CSCC[C@H](NC(=O)[C@H](CC(C)C)NC(=O)CN)C(N)=O"  # CHEBI:191172 molecule WITH an amide bond, e.g. a peptide / acetamide
+AMIDE_NEGATIVE_SMILES = "NCC(=O)O"  # CHEBI:15428 molecule WITHOUT an amide bond, e.g. an alcohol
+AMIDE_CARBOXYLIC_ACID_SMILES = "CC(N)CC(=O)O"  # CHEBI:37081 carboxylic acid (C=O present but no amide N)
+
+CARBOXY_POSITIVE_SMILES = "O=C(O)C1CCCN1"  # CHEBI:26271 molecule WITH a carboxy residue, e.g. acetic acid
+CARBOXY_NEGATIVE_SMILES = "N[C@H]1COC(O)[C@H](O)[C@H]1O"  # CHEBI:46991 molecule WITHOUT any carbonyl, e.g. an alkane
+
+AMINO_PRIMARY_AMINE_SMILES = "CC(N)Cc1ccccc1"  # CHEBI:132233 primary amine, e.g. methylamine
+AMINO_ALPHA_AMINO_ACID_SMILES = "NC(Cc1ccccc1)C(=O)O"  # CHEBI:28044 alpha-amino acid, e.g. glycine
+AMINO_NITRO_SMILES = "O=[N+]([O-])Cl"  # CHEBI:142774 nitro compound (N present but not an amino residue)
+AMINO_NO_NITROGEN_SMILES = "CSC(C)CC(=O)OCC(C)C"  # CHEBI:168833 molecule without any nitrogen, e.g. an alkane
+
+
+def _mol(smiles: str) -> Chem.Mol:
+    if not smiles:
+        pytest.skip("placeholder SMILES not set")
+    mol = Chem.MolFromSmiles(smiles)
+    assert mol is not None, f"invalid SMILES: {smiles!r}"
+    return mol
+
+
+def test_spec_amide_bond_detection(checker: "ModelCheckerTestWrapper"):
+    checker.add_background_definitions({"amide_bond": AMIDE_BOND_DEF})
+    formula_str = "hasAmideBond <=> ?[Ac, Ao, An]: amide_bond(Ac, Ao, An)"
+
+    assert checker.check_formula_for_molecule(formula_str, _mol(AMIDE_POSITIVE_SMILES)) is True
+    assert checker.check_formula_for_molecule(formula_str, _mol(AMIDE_NEGATIVE_SMILES)) is False
+    # A carboxylic acid has a C=O but no amide nitrogen, so it must not match.
+    assert (
+        checker.check_formula_for_molecule(formula_str, _mol(AMIDE_CARBOXYLIC_ACID_SMILES))
+        is False
+    )
+
+
+def test_spec_carboxy_residue_detection(checker: "ModelCheckerTestWrapper"):
+    checker.add_background_definitions({"carboxy_residue": CARBOXY_RESIDUE_DEF})
+    formula_str = "hasCarboxyResidue <=> ?[Ac, Ad, As]: carboxy_residue(Ac, Ad, As)"
+
+    assert (
+        checker.check_formula_for_molecule(formula_str, _mol(CARBOXY_POSITIVE_SMILES)) is True
+    )
+    assert (
+        checker.check_formula_for_molecule(formula_str, _mol(CARBOXY_NEGATIVE_SMILES)) is False
+    )
+
+
+def test_spec_amino_residue_detection(checker: "ModelCheckerTestWrapper"):
+    # amino_residue depends transitively on has_amino_nonconforming_neighbor and amide_bond.
+    checker.add_background_definitions(
+        {
+            "amide_bond": AMIDE_BOND_DEF,
+            "has_amino_nonconforming_neighbor": HAS_AMINO_NONCONFORMING_NEIGHBOR_DEF,
+            "amino_residue": AMINO_RESIDUE_DEF,
+        }
+    )
+    formula_str = "hasAminoResidue <=> ?[An]: amino_residue(An)"
+
+    assert (
+        checker.check_formula_for_molecule(formula_str, _mol(AMINO_PRIMARY_AMINE_SMILES))
+        is True
+    )
+    assert (
+        checker.check_formula_for_molecule(formula_str, _mol(AMINO_ALPHA_AMINO_ACID_SMILES))
+        is True
+    )
+    # A nitrogen with non-conforming (e.g. oxygen) neighbours is not an amino residue.
+    assert (
+        checker.check_formula_for_molecule(formula_str, _mol(AMINO_NITRO_SMILES)) is False
+    )
+    # No nitrogen at all -> no amino residue.
+    assert (
+        checker.check_formula_for_molecule(formula_str, _mol(AMINO_NO_NITROGEN_SMILES)) is False
+    )
+
+
 class ModelCheckerTestWrapper:
     def __init__(self) -> None:
         self.parser = TPTPParser()


### PR DESCRIPTION
This PR adds two categories of unittests for the `ModelChecker` class:
- generic logic tests that verify that the model checker can handle basic logic features
- real-world molecule-formula pairs from the peptide domain

The tests extend the test suite from https://github.com/sfluegel05/chemlog-peptides/pull/14